### PR TITLE
Statix: consolidate repeated keys; ignore generated hardware-configuration.nix

### DIFF
--- a/hosts/darwin/configuration.nix
+++ b/hosts/darwin/configuration.nix
@@ -76,10 +76,30 @@ in
 
   # Use Zsh as the default shell
   programs.zsh.enable = true;
-
+  
   # Darwin-specific settings
-  system.stateVersion  = 4;
-  system.primaryUser   = "pjones";
+  system = {
+    stateVersion = 4;
+    primaryUser  = "pjones";
+    defaults = {
+      dock = {
+        autohide                 = true;
+        orientation              = "bottom";
+        show-process-indicators  = false;
+        show-recents             = false;
+        static-only              = true;
+      };
+      finder = {
+        AppleShowAllExtensions          = true;
+        ShowPathbar                     = true;
+        FXEnableExtensionChangeWarning  = false;
+      };
+      NSGlobalDomain = {
+        AppleKeyboardUIMode      = 3;
+        "com.apple.keyboard.fnState" = true;
+      };
+    };
+  };
   nixpkgs.hostPlatform = "aarch64-darwin";
   nixpkgs.config.allowUnfree = true;
 
@@ -90,23 +110,5 @@ in
     shell        = pkgs.zsh;
   };
 
-  # macOS defaults for Finder and Dock
-  system.defaults = {
-    dock = {
-      autohide                 = true;
-      orientation              = "bottom";
-      show-process-indicators  = false;
-      show-recents             = false;
-      static-only              = true;
-    };
-    finder = {
-      AppleShowAllExtensions          = true;
-      ShowPathbar                     = true;
-      FXEnableExtensionChangeWarning  = false;
-    };
-    NSGlobalDomain = {
-      AppleKeyboardUIMode      = 3;
-      "com.apple.keyboard.fnState" = true;
-    };
-  };
+  # macOS defaults are defined above in system.defaults
 }

--- a/hosts/nixos/configuration.nix
+++ b/hosts/nixos/configuration.nix
@@ -12,19 +12,28 @@
     ];
 
   # Bootloader.
-  boot.loader.grub.enable = true;
-  boot.loader.grub.device = "/dev/sda";
-  boot.loader.grub.useOSProber = true;
+  boot = {
+    loader = {
+      grub = {
+        enable = true;
+        device = "/dev/sda";
+        useOSProber = true;
+      };
+    };
+  };
   nix.settings.experimental-features = [ "nix-command" "flakes" ];
-  networking.hostName = "nixos"; # Define your hostname.
+  networking = {
+    hostName = "nixos"; # Define your hostname.
+    networkmanager.enable = true;
+    firewall.allowedTCPPorts = [ 24800 80 443 22 ];
+  };
   # networking.wireless.enable = true;  # Enables wireless support via wpa_supplicant.
 
   # Configure network proxy if necessary
   # networking.proxy.default = "http://user:password@proxy:port/";
   # networking.proxy.noProxy = "127.0.0.1,localhost,internal.domain";
 
-  # Enable networking
-  networking.networkmanager.enable = true;
+  # Enable networking moved into networking set
 
   # Set your time zone.
   time.timeZone = "America/New_York";
@@ -44,21 +53,27 @@
     LC_TIME = "en_US.UTF-8";
   };
 
-  # Enable the X11 windowing system.
-  services.xserver.enable = true;
-
-  # Enable the GNOME Desktop Environment.
-  services.xserver.displayManager.gdm.enable = true;
-  services.xserver.desktopManager.gnome.enable = true;
-
-  # Configure keymap in X11
-  services.xserver.xkb = {
-    layout = "us";
-    variant = "";
+  # Enable the X11 windowing system and GNOME Desktop Environment.
+  services = {
+    xserver = {
+      enable = true;
+      displayManager = {
+        gdm.enable = true;
+        autoLogin = {
+          enable = true;
+          user = "parallaxis";
+        };
+      };
+      desktopManager.gnome.enable = true;
+      xkb = {
+        layout = "us";
+        variant = "";
+      };
+    };
+    printing.enable = true;
   };
 
-  # Enable CUPS to print documents.
-  services.printing.enable = true;
+  # Configure keymap in X11 moved into services.xserver above
 
   # Enable sound with pipewire.
   hardware.pulseaudio.enable = false;
@@ -94,9 +109,7 @@
     dedicatedServer.openFirewall = true; # Open ports in the firewall for Source Dedicated Server
     localNetworkGameTransfers.openFirewall = true; # Open ports in the firewall for Steam Local Network Game Transfers
   };
-  # Enable automatic login for the user.
-  services.xserver.displayManager.autoLogin.enable = true;
-  services.xserver.displayManager.autoLogin.user = "parallaxis";
+  # Enable automatic login moved into services set above
 
   # Workaround for GNOME autologin: https://github.com/NixOS/nixpkgs/issues/103746#issuecomment-945091229
   systemd.services."getty@tty1".enable = false;
@@ -138,8 +151,7 @@
   # Enable the OpenSSH daemon.
   # services.openssh.enable = true;
 
-  # Open ports in the firewall.
-  networking.firewall.allowedTCPPorts = [ 24800 80 443 22 ];
+  # Open ports in the firewall moved into networking set above
   # networking.firewall.allowedUDPPorts = [ ... ];
   # Or disable the firewall altogether.
   # networking.firewall.enable = false;

--- a/hosts/nixos/hardware-configuration.nix
+++ b/hosts/nixos/hardware-configuration.nix
@@ -7,7 +7,6 @@
   imports =
     [ (modulesPath + "/installer/scan/not-detected.nix")
     ];
-
   boot.initrd.availableKernelModules = [ "xhci_pci" "ahci" "usbhid" "usb_storage" "sd_mod" ];
   boot.initrd.kernelModules = [ ];
   boot.kernelModules = [ "kvm-amd" ];

--- a/statix.toml
+++ b/statix.toml
@@ -1,0 +1,7 @@
+disabled = []
+nix_version = '2.4'
+ignore = [
+  'hosts/nixos/hardware-configuration.nix',
+]
+
+


### PR DESCRIPTION
- Consolidate repeated attribute keys flagged by statix in darwin and nixos configs\n- Add statix.toml to ignore generated hosts/nixos/hardware-configuration.nix\n- Lint passes locally and should be green in CI