### PR TITLE
fix: missing c++ build deps

### DIFF
--- a/modules/darwin/home-manager.nix
+++ b/modules/darwin/home-manager.nix
@@ -73,13 +73,17 @@ in
                   rustflags = [
                     "-C", "link-arg=-L${pkgs.libiconv}/lib",
                     "-C", "link-arg=-liconv",
+                    "-C", "link-arg=-L${pkgs.libcxx}/lib",
+                    "-C", "link-arg=-lc++",
                     "-C", "target-cpu=native"
                   ]
 
                   [target.x86_64-apple-darwin]
                   rustflags = [
                     "-C", "link-arg=-L${pkgs.libiconv}/lib",
-                    "-C", "link-arg=-liconv"
+                    "-C", "link-arg=-liconv",
+                    "-C", "link-arg=-L${pkgs.libcxx}/lib",
+                    "-C", "link-arg=-lc++"
                   ]
 
                   # Linux targets (if needed)

--- a/modules/shared/home-manager.nix
+++ b/modules/shared/home-manager.nix
@@ -60,9 +60,9 @@ in
 
       # Rust/Cargo environment variables for macOS builds
       ${if pkgs.stdenv.isDarwin then ''
-        # libiconv linking for Rust on macOS
-        export LIBRARY_PATH="${pkgs.libiconv}/lib''${LIBRARY_PATH:+:$LIBRARY_PATH}"
-        export LDFLAGS="-L${pkgs.libiconv}/lib''${LDFLAGS:+ $LDFLAGS}"
+        # libiconv and libc++ linking for Rust on macOS
+        export LIBRARY_PATH="${pkgs.libiconv}/lib:${pkgs.libcxx}/lib''${LIBRARY_PATH:+:$LIBRARY_PATH}"
+        export LDFLAGS="-L${pkgs.libiconv}/lib -L${pkgs.libcxx}/lib''${LDFLAGS:+ $LDFLAGS}"
         
         # Compiler flags for aarch64-darwin
         # Use clang (not gcc) for proper Apple Silicon support

--- a/overlays/onetbb-skip-tests.nix
+++ b/overlays/onetbb-skip-tests.nix
@@ -11,3 +11,4 @@ if prev.stdenv.isLinux then {
   });
 } else { }
 
+


### PR DESCRIPTION
This pull request updates the Rust build configuration for macOS to ensure proper linking with `libc++` in addition to `libiconv`. This change addresses potential issues with C++ standard library dependencies when building Rust projects on macOS. The main changes are as follows:

**Rust build configuration improvements (macOS):**

* Updated the `rustflags` in `modules/darwin/home-manager.nix` to add linker arguments for `libc++` (`-L${pkgs.libcxx}/lib` and `-lc++`) for both general and `x86_64-apple-darwin` targets, ensuring Rust binaries link against the correct C++ standard library.
* Modified the environment variable setup in `modules/shared/home-manager.nix` to include `libc++` paths in `LIBRARY_PATH` and `LDFLAGS` for macOS builds, further ensuring that both `libiconv` and `libc++` are available during linking.

**Other:**

* Minor whitespace change in `overlays/onetbb-skip-tests.nix` with no functional impact.