### PR TITLE
chore: add agent skill config and fix CI failures

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,8 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(gh api *)",
+      "Bash(gh run *)"
+    ]
+  }
+}

--- a/.claude/skills/nix-profile-manager/SKILL.md
+++ b/.claude/skills/nix-profile-manager/SKILL.md
@@ -1,0 +1,148 @@
+---
+name: nix-profile-manager
+description: Expert guidance for agents to manage local Nix profiles for installing tools and dependencies. Covers flakes, profile management, package searching, and registry configuration.
+---
+
+# Nix Profile Manager for Agents
+
+## Overview
+
+This skill enables agents to maintain a local Nix profile in a user-provided directory, allowing dynamic installation of tools without requiring system-wide package management or sudo access.
+
+## Quick Start: Setting Up a Local Profile
+
+Users should provide a directory in their `PATH` for the agent to manage, and ensure the `AGENT_PROFILE` env var contains this directory so the agent knows where it is.
+
+Then the agent just does:
+
+```bash
+nix profile add --profile "$AGENT_PROFILE" "nixpkgs#git"
+```
+
+The `--profile` flag tells Nix to store the profile metadata in that location.
+The `bin` dir created by Nix in the profile must be in the PATH.
+
+NOTE: on older Nix versions, the `add` sub-command was called `install`. Keep this in mind if you get errors saying that "add" does not exist.
+
+## Core Concepts
+
+### Profiles
+
+A **profile** is a directory containing:
+- `manifest.json` - list of installed packages and their flake references
+- `bin`, `lib`, `share`, etc. - folders with symlinks to binaries, libs, docs in the Nix store
+
+When you run `nix profile add`, Nix updates the manifest and recreates symlinks.
+
+### Flakes
+
+A **flake** is a standardized Nix package collection with:
+- A `flake.nix` file defining inputs and outputs
+- Deterministic versioning via `flake.lock`
+- Multiple output schemes (packages, overlays, modules, etc.)
+
+**Common flakes:**
+- `nixpkgs` - Standard package library (the default registry), usually an alias for `github:NixOS/nixpkgs/nixpkgs-unstable`
+- Custom flakes from GitHub (e.g., `github:user/repo`)
+
+### Packages vs. Flakes
+
+- **Package**: A single tool (e.g., `git`, `python311`)
+- **Flake**: A collection of packages, accessed as `<flake>#<package>`
+
+IMPORTANT: In some flakes (like `nixpkgs`) packages can be nested: `<flake>#<scope>.<package>`
+
+## Essential Commands
+
+### Search for Packages
+
+```bash
+# Search in nixpkgs flake:
+nix search nixpkgs git
+
+# Search in specific (fully qualified) flake
+nix search "github:user/repo[/branch]" <package-name>
+
+# Or get a more detailed JSON output
+nix search nixpkgs python3 --json | jq '.[].pname'
+```
+
+### Manage Profile
+
+```bash
+# Add package
+nix profile add --profile <profile_path> "<flake>#<package>"
+
+# List installed packages
+nix profile list --profile <profile_path>
+
+# Remove by index or element number
+nix profile remove --profile <path>/profile 0
+
+# Upgrade packages
+nix profile upgrade --profile <profile_path> <package_name>
+nix profile upgrade --profile <profile_path> --all  # All packages installed in this profile
+```
+
+### Registry Management
+
+```bash
+# List available flake aliases
+nix registry list
+
+# Add custom registry entry (user-level)
+nix registry add myflake github:user/repo/branch
+```
+
+## General Workflow
+
+```bash
+# Determine profile path:
+echo $AGENT_PROFILE  # If not defined, ask the user which profile to use!!
+
+# Search for the package
+nix search nixpkgs git
+
+# Add it
+nix profile add --profile "$AGENT_PROFILE" "nixpkgs#git"
+
+# Just use it!
+tool-cmd ...
+```
+
+## Important Details
+
+- **Profile path `bin` sub-folder should be in PATH**: The directory containing the profile must be in `$PATH` for linked binaries to be accessible
+- **Flake references are immutable**: `nixpkgs#git` resolves to the current nixpkgs version; use `github:user/repo/ref#package` to pin to specific refs
+- **Profile locking**: Only one agent should modify a profile at a time; locking is not automatic
+- **Store links don't expire**: Nix store paths remain valid even if the flake changes; profiles maintain old package paths if needed
+
+## Troubleshooting
+
+**Package not found:**
+- Ensure flake name is correct: `nix registry list` shows available aliases
+- Search with `nix search <flake> <partial-name>` to find exact package name
+
+**Command not in PATH after install:**
+- Check profile directory is in `$PATH`: `echo $PATH`
+- Verify $AGENT_PROFILE was created: `ls -la $AGENT_PROFILE` (adjust path as needed)
+
+**Permission denied:**
+- Local profiles DO NOT require sudo. Report to user in case of permission problems
+
+## References
+
+- `references/flakes.md` - In-depth flake concepts and GitHub references
+- `references/package-search.md` - Advanced package discovery techniques
+- `references/profile-internals.md` - Profile structure and manifest format
+- `references/registry.md` - Custom registry configuration and pinning
+
+## For Agent Implementation
+
+When implementing profile management in an agent:
+
+1. **Accept profile path as environment variable or parameter** - e.g., `AGENT_PROFILE` or function arg
+2. **Always search before installing** - verify package exists and name is exact
+3. **Use `--json` output for parsing** - more reliable than text output
+4. **Handle errors gracefully** - packages may not exist in all flakes
+5. **Notify about profile modifications** - help users track what was installed

--- a/.claude/skills/nix-profile-manager/references/flakes.md
+++ b/.claude/skills/nix-profile-manager/references/flakes.md
@@ -1,0 +1,113 @@
+# Flakes: Deep Dive
+
+## What is a Flake?
+
+A flake is a directory with a `flake.nix` file that defines:
+- **Inputs**: Dependencies on other flakes
+- **Outputs**: What this flake provides (packages, modules, functions, etc.)
+- **Lock file**: `flake.lock` that pins exact versions
+
+Flakes are the modern way to version and distribute Nix packages reproducibly.
+
+## Flake References
+
+### Format
+
+```
+<flake-ref>[/<path>][?<query>[=<value>]...]
+```
+
+### Types
+
+#### 1. Registry Aliases (Recommended for agents)
+
+```bash
+nixpkgs#git        # Resolves via nix registry
+unstable#python3   # If configured as registry entry
+```
+
+Registry entries are defined locally and resolve to underlying flake references.
+
+#### 2. GitHub References
+
+```bash
+github:user/repo               # Latest commit on default branch
+github:user/repo/branch-name   # Specific branch
+github:user/repo/commit-hash   # Specific commit
+github:user/repo/v1.0.0        # Tag reference
+```
+
+#### 3. Flake URLs
+
+```bash
+git+https://github.com/user/repo.git    # Git URL
+file:///home/user/my-flake              # Local path
+```
+
+#### 4. Pinning Versions
+
+```bash
+# By tag (recommended for stable)
+github:user/repo/v1.0
+
+# By commit hash (most reproducible)
+github:user/repo/abc1234def5678
+
+# By branch (least stable, not recommended)
+github:user/repo/main
+```
+
+## Important: nixpkgs Variations
+
+### Main variants:
+
+- `nixpkgs` - Latest release of nixpkgs (stable)
+- `nixpkgs/nixos-24.11` - Specific NixOS release (stable)
+- `nixpkgs/nixos-unstable` - Cutting-edge but reviewed
+- `nixpkgs/master` - Bleeding edge, use with caution
+
+### When to use each:
+
+- **nixpkgs**: Default for most tools, new packages added regularly (corresponds to the `nixpkgs-unstable` branch usually)
+- **Custom flakes**: Need specific configuration or unpublished packages
+
+## Flake Outputs
+
+A flake can output multiple things:
+
+```nix
+{
+  outputs = {
+    packages.x86_64-linux.git = ...;      # Package for Linux x86_64
+    packages.aarch64-darwin.python3 = ... # Package for macOS ARM
+    overlays.default = ...;               # Overlay for custom modifications
+    modules.default = ...;                # NixOS module
+  };
+}
+```
+
+When using `nix search` or `nix profile add`, Nix picks the appropriate output for your system.
+
+## Checking What a Flake Provides
+
+```bash
+# List all outputs in a flake
+nix flake show nixpkgs
+
+# Show attributes in packages
+nix flake show github:user/repo | grep packages
+```
+
+## For Agents
+
+### Safe defaults:
+
+- Use `nixpkgs#<package>` for most tools
+- Use registry aliases defined by the user
+- Use search before installing to get exact package names
+
+### When a package can't be found:
+
+1. Search across different flakes if user has configured alternatives in the registry
+2. Check if package name contains dashes (e.g., `python3-pip` vs `python3`)
+3. Ask user which flake to use, or to add custom flake to the registry if needed

--- a/.claude/skills/nix-profile-manager/references/package-search.md
+++ b/.claude/skills/nix-profile-manager/references/package-search.md
@@ -1,0 +1,160 @@
+# Package Search Techniques
+
+## Basic Search
+
+```bash
+nix search nixpkgs git
+```
+
+This searches package names and descriptions. Returns multiple results if any match.
+
+## JSON Output for Parsing
+
+```bash
+nix search nixpkgs git --json
+```
+
+Output format:
+```json
+{
+  "nixpkgs#git": {
+    "pname": "git",
+    "version": "2.42.0",
+    "description": "Distributed version control system",
+    "longDescription": "...",
+    "outputs": ["out"],
+    "stdenv": "..."
+  }
+}
+```
+
+Key fields:
+- **pname**: Exact package name
+- **version**: Current version in flake
+- **description**: Short summary
+
+## Advanced Search Patterns
+
+### Search in specific flake
+
+```bash
+nix search github:user/repo mypackage
+```
+
+### Narrow down results
+
+```bash
+# Search with multiple terms
+nix search nixpkgs python 3.11
+
+# Use partial names
+nix search nixpkgs "^git$"  # Exact match (regex supported)
+```
+
+### Find packages by attribute path
+
+If you know the full attribute path:
+
+```bash
+# Direct lookup (faster than search)
+nix eval --raw nixpkgs#git
+```
+
+## Common Package Name Gotchas
+
+### Dashes vs underscores
+
+```bash
+# These are equivalent:
+nix search nixpkgs python_3_11
+nix search nixpkgs python-3-11
+nix search nixpkgs python311  # Also works
+```
+
+Nix automatically handles these variations.
+
+### Version numbers in names
+
+```bash
+nix search nixpkgs python3.11  # Specific version
+nix search nixpkgs python311   # Same thing
+nix search nixpkgs python      # All python variants
+```
+
+### Using the exact pname field
+
+When search returns multiple results, look for exact `pname` match:
+
+```bash
+nix search nixpkgs --json python | jq -r '.[].pname'
+```
+
+Output might show:
+- python3
+- python3-minimal
+- python311
+- python312
+- python310-pip
+
+Use the exact pname with the flake: `nixpkgs#python3.11`
+
+## Checking Package Availability Across Flakes
+
+Some packages exist only in certain flakes:
+
+```bash
+# Try multiple registries
+nix search nixpkgs <package> 2>/dev/null && echo "In nixpkgs"
+nix search nixpkgs/nixos-unstable <package> 2>/dev/null && echo "In unstable"
+nix search github:nix-community/nixpkgs-firefox-release <package> 2>/dev/null && echo "In firefox-release"
+```
+
+## Interactive Discovery
+
+```bash
+# List all available packages (large output)
+nix search nixpkgs . | less
+
+# List with descriptions
+nix search nixpkgs --json | jq -r '.[] | "\(.pname) (\(.version)): \(.description)"'
+
+# Find packages by description pattern
+nix search nixpkgs --json | jq -r '.[] | select(.description | contains("web browser"))'
+```
+
+## Performance Considerations
+
+- `nix search` may take a few seconds on first run
+- Results are cached locally
+- For repeated searches, store results in variable:
+
+```bash
+SEARCH_RESULT=$(nix search nixpkgs git --json)
+# Use $SEARCH_RESULT multiple times without re-searching
+```
+
+## What Happens When Package Isn't Found
+
+1. **Package doesn't exist in flake**
+   - Solution: Try another flake, or report to user
+
+2. **Typo in package name**
+   - Solution: Use `nix search` with partial match
+
+3. **Package in different output**
+   - Some flakes (nixpkgs notably) organize as `flake#scope.package`
+   - Solution: Check the full attribute path returned by `nix search`, or check with `nix flake show <flake>`
+
+4. **System-specific availability**
+   - Package may only exist for certain architectures
+   - Solution: Check error message, may need different flake
+
+## For Agents
+
+### Safe search workflow:
+
+1. Always search before installing: `nix search <flake> <partial-name>`
+2. Extract exact pname from JSON: `jq -r '.[] | .pname' | head -1`
+3. Build full reference: `echo "<flake>#<pname>"`
+4. Verify before install: `nix search <flake> "<pname>"` (verify exact match)
+5. Install with full reference: `nix profile add --profile <path> "<flake>#<pname>"`

--- a/.claude/skills/nix-profile-manager/references/profile-internals.md
+++ b/.claude/skills/nix-profile-manager/references/profile-internals.md
@@ -1,0 +1,136 @@
+# Profile Internals
+
+## Profile Structure
+
+When you create a profile at `~/.local/profile`, Nix creates:
+
+```
+~/.local/profile/
+├── manifest.json       # List of installed packages
+├── manifest.json.lock  # Lock file (auto-generated)
+├── bin/               # Symlinks to executables
+│   ├── git -> /nix/store/xyz-git-2.42.0/bin/git
+│   ├── python -> /nix/store/abc-python3-3.11/bin/python
+│   └── ...
+```
+
+## Manifest Format
+
+The `manifest.json` tracks what's installed:
+
+```json
+{
+  "version": 6,
+  "elements": [
+    {
+      "inputs": {
+        "nixpkgs": {
+          "id": "nixpkgs",
+          "originalRef": "flake:nixpkgs",
+          "lastModified": 1699300000,
+          "narHash": "sha256-xxx..."
+        }
+      },
+      "attrPath": "legacyPackages.x86_64-linux.git",
+      "originalUrl": "flake:nixpkgs",
+      "storePath": "/nix/store/xyz-git-2.42.0"
+    }
+  ]
+}
+```
+
+### Key fields:
+
+- **inputs**: Which flake and version this package comes from
+- **attrPath**: The full attribute path in the flake
+- **storePath**: Where in the Nix store the package lives
+- **narHash**: Content hash for verification
+
+## How nix profile add Works
+
+1. **Resolve flake reference**: `nixpkgs#git` → look up actual flake URL
+2. **Evaluate flake**: Run Nix evaluation to get package
+3. **Build if needed**: Download or build the package
+4. **Read manifest.json**: Load existing profile state
+5. **Add new element**: Append package info to manifest
+6. **Recompute symlinks**: Create/update symlinks in profile directory
+7. **Verify**: Check that binaries are accessible
+
+## Profile Updates with nix profile upgrade
+
+When you run `nix profile upgrade --all`:
+
+1. Re-evaluate all flakes referenced in manifest
+2. Check for newer versions available
+3. Download/build newer versions
+4. Update manifest with new package info
+5. Recompute symlinks to point to new versions
+6. Keep old versions in Nix store (safe to keep, but takes disk space)
+
+## Why Symlinks?
+
+Nix keeps all package versions in the store (`/nix/store/`) which is:
+- **Immutable**: Packages never change
+- **Content-addressed**: Same content = same path
+- **Garbage-collected**: Unused packages can be deleted by calling just one command
+
+Profiles create symlinks to selected packages, so you can have multiple versions installed and switch between them by updating the profile.
+
+## Profiles are Versioned
+
+```bash
+# Check history
+nix profile history --profile ~/.local/profile
+
+# Rollback to previous state
+nix profile rollback --profile ~/.local/profile
+```
+
+## Path Considerations
+
+### Profile path is metadata, not binaries
+
+```bash
+nix profile add --profile ~/.local/profile "nixpkgs#git"
+```
+
+- `~/.local/profile` is where Nix stores profile metadata
+- Actual binaries are symlinks in `~/.local/profile/bin/`
+
+To use the binaries, either:
+1. Add `~/.local/profile/bin` to PATH
+2. Create symlinks from some other folder in PATH to `~/.local/profile/bin/*`
+
+### User Convention
+
+Most users set up:
+```bash
+nix profile add --profile ~/.nix-profile "nixpkgs#git"
+export PATH="$HOME/.nix-profile/bin:$PATH"
+```
+
+## Multiple Profiles
+
+You can have multiple profiles for different purposes:
+
+```bash
+# Development tools
+nix profile add --profile ~/.my-profiles/dev "nixpkgs#python311" "nixpkgs#nodejs"
+
+# Utilities
+nix profile add --profile ~/.my-profiles/util "nixpkgs#ripgrep" "nixpkgs#jq"
+
+# In your shell
+export PATH="$HOME/.my-profiles/dev/bin:$HOME/.my-profiles/util/bin:$PATH"
+```
+
+Each profile has its own manifest and can be updated independently.
+
+## Lock Files
+
+The `manifest.json.lock` is auto-generated and contains:
+- Resolved flake URLs
+- Exact commit hashes
+- Content hashes
+
+Don't edit manually. It ensures reproducibility across sessions.

--- a/.claude/skills/nix-profile-manager/references/registry.md
+++ b/.claude/skills/nix-profile-manager/references/registry.md
@@ -1,0 +1,233 @@
+# Nix Registry
+
+## What is the Registry?
+
+The Nix registry is a local mapping of **aliases** to **flake URLs**. It allows you to use short names instead of full URLs:
+
+```bash
+# Without registry (full URL)
+nix profile add --profile ~/profile github:nixos/nixpkgs/nixpkgs-unstable#git
+
+# With registry alias
+nix search nixpkgs git  # "nixpkgs" is a registry alias
+nix profile add --profile ~/profile nixpkgs#git
+```
+
+## Default Registry
+
+Nix ships with default aliases:
+
+```
+nixpkgs                → github:nixos/nixpkgs/... (whatever branch was set by the Nix installer)
+nixpkgs/nixos-24.11    → github:nixos/nixpkgs/nixos-24.11
+nixpkgs/nixos-unstable → github:nixos/nixpkgs/nixos-unstable
+```
+
+Check your system's defaults:
+
+```bash
+nix registry list
+```
+
+Example output:
+```
+system: flake:nixpkgs from git+ssh://git@github.com/nixos/nixpkgs
+global flake:nixpkgs from github:nixos/nixpkgs (pinned to 699ba2a)
+home flake:nixpkgs from git+ssh://git@github.com/... (if user added)
+```
+
+## Registry Scopes
+
+Nix searches registries in order:
+
+1. **Home** (`$XDG_CONFIG_HOME/nix/registry.json`)
+   - User-level overrides (highest priority)
+   - Persist across sessions
+
+2. **Global** (`/etc/nix/registry.json`)
+   - System-wide defaults
+   - Usually set by NixOS or Nix installer
+
+3. **System** (built-in)
+   - Fallback defaults
+
+## Managing Registry Entries
+
+### List all entries
+
+```bash
+nix registry list
+```
+
+Shows all registry entries with their scope and pinned status.
+
+### Add a custom alias (user-level)
+
+```bash
+# Simple alias
+nix registry add myflake github:user/repo
+
+# With specific branch
+nix registry add myflake github:user/repo/develop
+
+# Pin to specific commit (most reproducible)
+nix registry add myflake github:user/repo/abc1234def5678
+```
+
+These are stored in `~/.config/nix/registry.json`.
+
+### Remove an alias
+
+```bash
+nix registry remove myflake
+```
+
+## Advanced Registry Configuration
+
+### Direct JSON editing
+
+If you prefer, edit `~/.config/nix/registry.json` directly:
+
+```json
+{
+  "version": 2,
+  "flakes": [
+    {
+      "from": {
+        "type": "indirect",
+        "id": "myproject"
+      },
+      "to": {
+        "type": "github",
+        "owner": "myorg",
+        "repo": "myproject",
+        "rev": "abc1234def567890",
+        "dir": ""
+      }
+    }
+  ]
+}
+```
+
+Then verify with:
+
+```bash
+nix registry list
+```
+
+### Dynamic registry for development
+
+Instead of modifying the global registry, create a `flake.nix` locally:
+
+```bash
+cd ~/myproject
+nix flake init
+
+# Edit flake.nix, then:
+nix flake update
+
+# Then install the local flake in a profile:
+nix profile add "~/myproject#packages.x86_64-linux.mytool"
+```
+
+## Common Registry Patterns
+
+### Stable vs Unstable
+
+```bash
+# Use stable for production
+nix registry add stable github:nixos/nixpkgs/nixos-24.11
+
+# Use unstable for latest features
+nix registry add unstable github:nixos/nixpkgs/nixos-unstable
+
+# In usage
+nix profile add --profile ~/profile stable#git           # 2.42.0
+nix profile add --profile ~/profile unstable#neovim     # 0.10.0 (newer)
+```
+
+### Organization-specific packages
+
+```bash
+# Company internal tools
+nix registry add company-tools github:mycompany/nix-packages
+
+# Use in profile
+nix profile add --profile ~/profile company-tools#internal-cli
+```
+
+### Local development flake
+
+```bash
+# Point to local directory during development (must be absolute path)
+nix registry add mydev /home/user/myproject
+
+# Once merged to main, switch to GitHub
+nix registry add mydev github:user/myproject
+```
+
+## For Agents
+
+### Best practices for registry usage:
+
+1. **Check available registries first**
+   ```bash
+   nix registry list | grep -E "^(home|global)"
+   ```
+
+2. **Assume nixpkgs exists** - it's always available
+   ```bash
+   nix profile add --profile ~/profile nixpkgs#<package>
+   ```
+
+3. **Ask user before adding registry entries** - avoid polluting their configuration
+   ```bash
+   echo "Would you like me to add a registry entry for <flake>?"
+   ```
+
+4. **Use absolute paths or GitHub URLs** for clarity
+   - Good: `github:nixos/nixpkgs/nixos-24.11`
+   - Okay: `nixpkgs` (if already registered)
+   - Bad: `~/my-flake` (local paths break on different machines)
+
+5. **Document custom registries** - note what was added:
+   ```bash
+   echo "Added registry entry: nix registry add myflake github:user/repo"
+   ```
+
+## Troubleshooting
+
+### Alias not resolving
+
+```bash
+# Check if it exists
+nix registry list | grep myflake
+
+# Try explicit URL
+nix search github:user/repo <package>
+
+# If works, register it
+nix registry add myflake github:user/repo
+```
+
+### Multiple versions of same flake
+
+```bash
+# You can have different aliases for different versions
+nix registry add nixpkgs-stable github:nixos/nixpkgs/nixos-24.11
+nix registry add nixpkgs-latest github:nixos/nixpkgs/nixos-unstable
+
+# Use different aliases in profiles
+nix profile add --profile ~/stable nixpkgs-stable#git
+nix profile add --profile ~/latest nixpkgs-latest#git
+```
+
+### Registry entry gone after update
+
+If you removed an entry by accident:
+
+```bash
+# It's still in git history (if using NixOS/Home Manager)
+# Or re-add it
+nix registry add myflake github:user/repo
+```

--- a/.github/workflows/auto-update-flakes.yml
+++ b/.github/workflows/auto-update-flakes.yml
@@ -31,6 +31,6 @@ jobs:
           pr-labels: 'dependencies,automerge'
           branch: 'ci/flake-update'
           # Skip updating the secrets input since CI can't access the private repo
-          inputs-to-update: 'nixpkgs agenix home-manager darwin nix-homebrew homebrew-bundle homebrew-core homebrew-cask disko fenix'
+          inputs: 'nixpkgs agenix home-manager darwin nix-homebrew homebrew-bundle homebrew-core homebrew-cask disko fenix'
 
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,17 @@
+## Agent skills
+
+### Issue tracker
+
+Issues live in GitHub Issues (`parallaxisjones/dotfiles`). See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Default label vocabulary — needs-triage, needs-info, ready-for-agent, ready-for-human, wontfix. See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context repo — one `CONTEXT.md` + `docs/adr/` at the repo root. See `docs/agents/domain.md`.
+
+### Available skills
+
+- **nix-profile-manager** (`.claude/skills/nix-profile-manager/`) — manage local Nix profiles imperatively: install, search, and upgrade packages via `nix profile` without touching the system config. Read `SKILL.md` before running any `nix profile` commands; consult `references/` for flakes, package search, profile internals, and registry configuration.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,38 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root
+- **`docs/adr/`** — read ADRs that touch the area you're about to work in
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The producer skill (`/grill-with-docs`) creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+Single-context repo:
+
+```
+/
+├── CONTEXT.md
+├── docs/adr/
+│   ├── 0001-choose-zfs-for-helios64.md
+│   ├── 0002-networking-1g-vs-2_5g.md
+│   └── 0003-backups-restic-rclone-with-agenix.md
+└── apps/
+└── hosts/
+└── modules/
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/grill-with-docs`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 (example) — but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,22 @@
+# Issue tracker: GitHub
+
+Issues and PRDs for this repo live as GitHub issues. Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,15 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in parallaxisjones/skills | Label in our tracker | Meaning                                  |
+| ------------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`                  | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`                    | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`               | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`               | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                       | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+Edit the right-hand column to match whatever vocabulary you actually use.

--- a/overlays/onetbb-skip-tests.nix
+++ b/overlays/onetbb-skip-tests.nix
@@ -3,7 +3,7 @@
 # The tests pass locally but fail in CI environments, so we disable them
 _final: prev:
 if prev.stdenv.isLinux then {
-  onetbb = prev.onetbb.overrideAttrs (oldAttrs: {
+  onetbb = prev.onetbb.overrideAttrs (_: {
     # Disable the check phase
     doCheck = false;
     # Override checkPhase


### PR DESCRIPTION
## Summary

- **Agent skill setup**: adds `CLAUDE.md` + `docs/agents/` config so engineering skills (`to-issues`, `triage`, `qa`, `improve-codebase-architecture`, etc.) know where issues live, what triage labels to use, and how to read domain docs
- **nix-profile-manager skill**: bundles the [YPares/agent-skills nix-profile-manager](https://github.com/YPares/agent-skills/blob/main/nix-profile-manager/SKILL.md) under `.claude/skills/` so agents can manage Nix profiles imperatively without touching system config
- **Fix deadnix CI failure**: rename unused `oldAttrs` → `_` in `overlays/onetbb-skip-tests.nix` (introduced in #42)
- **Fix Auto Update Flakes CI failure**: `DeterminateSystems/update-flake-lock@v28` renamed `inputs-to-update` → `inputs`; the unrecognised key was silently ignored, causing CI to attempt updating the private `nix-secrets` SSH input and fail every week

## Test plan

- [ ] CI lint-eval passes (deadnix no longer flags onetbb overlay)
- [ ] Auto Update Flakes workflow runs without the SSH fetch error on next Monday trigger (or via workflow_dispatch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)