### PR TITLE
chore: dedupe nixpkgs via input follows + GC on desktop

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3,8 +3,12 @@
     "agenix": {
       "inputs": {
         "darwin": "darwin",
-        "home-manager": "home-manager",
-        "nixpkgs": "nixpkgs",
+        "home-manager": [
+          "home-manager"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ],
         "systems": "systems"
       },
       "locked": {
@@ -164,27 +168,8 @@
     "home-manager": {
       "inputs": {
         "nixpkgs": [
-          "agenix",
           "nixpkgs"
         ]
-      },
-      "locked": {
-        "lastModified": 1745494811,
-        "narHash": "sha256-YZCh2o9Ua1n9uCvrvi5pRxtuVNml8X2a03qIFfRKpFs=",
-        "owner": "nix-community",
-        "repo": "home-manager",
-        "rev": "abfad3d2958c9e6300a883bd443512c55dfeb1be",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "home-manager",
-        "type": "github"
-      }
-    },
-    "home-manager_2": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_2"
       },
       "locked": {
         "lastModified": 1780099287,
@@ -283,38 +268,6 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1754028485,
-        "narHash": "sha256-IiiXB3BDTi6UqzAZcf2S797hWEPCRZOwyNThJIYhUfk=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "59e69648d345d6e8fef86158c555730fa12af9de",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-25.05",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_2": {
-      "locked": {
-        "lastModified": 1779877693,
-        "narHash": "sha256-NOF9NAREhxr50bbBfVcVOq+ArCMSoe8dP79Pk2uyARk=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "4100e830e085863741bc69b156ec4ccd53ab5be0",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_3": {
-      "locked": {
         "lastModified": 1779560665,
         "narHash": "sha256-tpyBcxPpcQb8ukyNF7DoCwfSY3VPsxHoYwj00Cayv5o=",
         "owner": "nixos",
@@ -337,13 +290,13 @@
         "darwin": "darwin_2",
         "disko": "disko",
         "fenix": "fenix",
-        "home-manager": "home-manager_2",
+        "home-manager": "home-manager",
         "homebrew-bundle": "homebrew-bundle",
         "homebrew-cask": "homebrew-cask",
         "homebrew-core": "homebrew-core",
         "my-skills": "my-skills",
         "nix-homebrew": "nix-homebrew",
-        "nixpkgs": "nixpkgs_3",
+        "nixpkgs": "nixpkgs",
         "secrets": "secrets"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -2,8 +2,15 @@
   description = "General Purpose Configuration for macOS and NixOS";
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
-    agenix.url = "github:ryantm/agenix";
-    home-manager.url = "github:nix-community/home-manager";
+    agenix = {
+      url = "github:ryantm/agenix";
+      inputs.nixpkgs.follows = "nixpkgs";
+      inputs.home-manager.follows = "home-manager";
+    };
+    home-manager = {
+      url = "github:nix-community/home-manager";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
     darwin = {
       url = "github:LnL7/nix-darwin/master";
       inputs.nixpkgs.follows = "nixpkgs";

--- a/hosts/nixos/configuration.nix
+++ b/hosts/nixos/configuration.nix
@@ -32,22 +32,24 @@
     # machine from desktop to server. Re-enable when needed.
     # binfmt.emulatedSystems = [ "aarch64-linux" ];
   };
-  nix.settings = {
-    experimental-features = [ "nix-command" "flakes" ];
-    # Constrain parallelism to avoid OOM under load
-    max-jobs = 2;
-    cores = 2;
-    # Keep features minimal for this host
-    system-features = [ "kvm" ];
-    extra-platforms = [ "aarch64-linux" "i686-linux" ];
+  nix = {
+    settings = {
+      experimental-features = [ "nix-command" "flakes" ];
+      # Constrain parallelism to avoid OOM under load
+      max-jobs = 2;
+      cores = 2;
+      # Keep features minimal for this host
+      system-features = [ "kvm" ];
+      extra-platforms = [ "aarch64-linux" "i686-linux" ];
+    };
+    # Keep the store tidy on this always-on host: weekly GC + automatic dedup.
+    gc = {
+      automatic = true;
+      dates = "weekly";
+      options = "--delete-older-than 30d";
+    };
+    optimise.automatic = true;
   };
-  # Keep the store tidy on this always-on host: weekly GC + automatic dedup.
-  nix.gc = {
-    automatic = true;
-    dates = "weekly";
-    options = "--delete-older-than 30d";
-  };
-  nix.optimise.automatic = true;
   networking = {
     hostName = "nixos"; # Define your hostname.
     networkmanager.enable = true;

--- a/hosts/nixos/configuration.nix
+++ b/hosts/nixos/configuration.nix
@@ -41,6 +41,13 @@
     system-features = [ "kvm" ];
     extra-platforms = [ "aarch64-linux" "i686-linux" ];
   };
+  # Keep the store tidy on this always-on host: weekly GC + automatic dedup.
+  nix.gc = {
+    automatic = true;
+    dates = "weekly";
+    options = "--delete-older-than 30d";
+  };
+  nix.optimise.automatic = true;
   networking = {
     hostName = "nixos"; # Define your hostname.
     networkmanager.enable = true;


### PR DESCRIPTION
## Context

Flake hygiene fixes identified in the homelab assessment. Two low-risk, high-ROI cleanups that make every future build faster and the always-on desktop tidier — no homelab/service work here.

## Changes

**`flake.nix` — dedupe nixpkgs via `follows`**
- `home-manager` now `inputs.nixpkgs.follows = "nixpkgs"`. It was pulling its **own** `nixpkgs` (confirmed in the old lock) — the classic footgun: Home Manager evaluated against a different nixpkgs than the system, doubling eval and risking version skew.
- `agenix` now follows `nixpkgs` + `home-manager`.

**`flake.lock` — regenerated, and un-tangled**
- The committed lock was already messy (likely a prior hands-free auto-merge): **three** `nixpkgs` nodes — including a stray `nixos-25.05` pin — and two `home-manager` nodes.
- Regeneration collapses it to a **single `nixpkgs`** node on `nixos-unstable` (matching what `flake.nix` declares), with `home-manager`/`agenix` following root.

**`hosts/nixos/configuration.nix` — store hygiene on the desktop**
- Added weekly `nix.gc` (`--delete-older-than 30d`) + `nix.optimise.automatic`. The darwin host already had GC; `helios64.nix` (CI stub) untouched.

## ⚠️ Reviewer note

Root `nixpkgs` moves off the stale `nixos-25.05` rev (~Aug 2025) onto current `nixos-unstable` (~May 2026) — this is the *correct* state per `flake.nix`, but a switch will **rebuild a large closure**. Preview before activating:

```bash
nix run .#build-dry
```

## Verification
- [x] `nix flake show` evaluates
- [x] `flake.lock` is valid JSON, single `nixpkgs` node, no conflict markers
- [ ] `nix run .#build-dry` previewed on a host
- [ ] `systemctl list-timers | grep nix-gc` after switch on the desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)