### PR TITLE
fix(nixos): wire binary caches + trusted-users on the desktop host

### DIFF
--- a/hosts/nixos/configuration.nix
+++ b/hosts/nixos/configuration.nix
@@ -41,6 +41,23 @@
       # Keep features minimal for this host
       system-features = [ "kvm" ];
       extra-platforms = [ "aarch64-linux" "i686-linux" ];
+      # Trust the primary admin so client-specified settings aren't dropped
+      # (otherwise nix logs "ignoring the client-specified setting ...,
+      # because you are not a trusted user"). parallaxis is in the wheel group.
+      trusted-users = [ "root" "@wheel" ];
+      # Binary caches. These previously lived in the now-orphaned
+      # hosts/nixos/default.nix (the old bspwm desktop config) and were never
+      # applied to this server host, so every build fell back to local compiles.
+      substituters = [
+        "https://cache.nixos.org"
+        "https://nix-community.cachix.org"
+        "https://parallaxisjones.cachix.org"
+      ];
+      trusted-public-keys = [
+        "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
+        "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
+        "parallaxisjones.cachix.org-1:A85H34pyLFZq2A3A0hB32/8CXuFNS3e4Js+KlKlP43Q="
+      ];
     };
     # Keep the store tidy on this always-on host: weekly GC + automatic dedup.
     gc = {


### PR DESCRIPTION
## Context

While debugging why `nix run .#build-switch` on the desktop (`nixos`) was compiling everything locally instead of substituting from Cachix, the root cause turned out to be orphaned config.

The Cachix `substituters`, `trusted-public-keys`, and `trusted-users` all live in `hosts/nixos/default.nix` — the **original bspwm desktop** config. When this box was converted desktop→server, the flake was repointed at a fresh `hosts/nixos/configuration.nix` and `default.nix` was left **imported nowhere**. So those settings were never applied to the running system.

### Symptoms this explains
- `warning: ignoring the client-specified setting 'system-features', because ... you are not a trusted user` — `parallaxis` wasn't in `trusted-users`.
- Builds compiling overlay packages (and freshly-bumped unstable bits) locally — the daemon only knew `cache.nixos.org`; the Cachix caches were never registered.

## Change

Fold the relevant `nix.settings` into the **active** host config (`hosts/nixos/configuration.nix`), reusing the values from `default.nix`:

- `trusted-users = [ "root" "@wheel" ]` — `parallaxis` is in `wheel`. (Uses the NixOS `wheel` group rather than the template's macOS-only `@admin`.)
- `substituters` + `trusted-public-keys` for `nix-community.cachix.org` and `parallaxisjones.cachix.org`, alongside `cache.nixos.org`.

Deliberately does **not** import `default.nix` wholesale — that would drag the entire X11/bspwm/nvidia/picom desktop back onto the server.

## Notes / follow-ups
- The *current* in-progress build won't benefit; daemon settings apply on the **next** switch after this lands.
- Your `parallaxisjones.cachix.org` cache may be under-populated — `docs/ROADMAP.md` notes the **CI Cachix push job "needs secret."** Worth wiring `CACHIX_AUTH_TOKEN` so overlays actually get pushed; otherwise this only helps via `nix-community` + `cache.nixos.org`.

## Verification
- [x] `statix check hosts/nixos/configuration.nix` clean
- [x] `nix eval .#nixosConfigurations.x86_64-linux.config.system.build.toplevel.drvPath` evaluates
- [ ] After switch on the desktop: `nix show-config | grep -E 'trusted-users|substituters'` reflects the caches, and a no-op rebuild substitutes rather than builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)