### PR TITLE
feat(nixos): homelab torrent + media stack

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -320,11 +320,11 @@
     "secrets": {
       "flake": false,
       "locked": {
-        "lastModified": 1779310281,
-        "narHash": "sha256-eAvMwwWIQpD7fERxspeD7WSdVb91vapGJjgdvXhwHgE=",
+        "lastModified": 1780434645,
+        "narHash": "sha256-4OwT+sMm/hfx/PSk+t3oWGNmhtJGigU3kRmoD6jrKqY=",
         "ref": "refs/heads/main",
-        "rev": "56b8a5ae68aacd3cd8150987c7f8e643afce61ee",
-        "revCount": 26,
+        "rev": "df6a7c411cbfa80579128e2cf1585e2d6a41b925",
+        "revCount": 27,
         "type": "git",
         "url": "ssh://git@github.com/parallaxisjones/nix-secrets.git"
       },

--- a/flake.lock
+++ b/flake.lock
@@ -320,11 +320,11 @@
     "secrets": {
       "flake": false,
       "locked": {
-        "lastModified": 1780434645,
-        "narHash": "sha256-4OwT+sMm/hfx/PSk+t3oWGNmhtJGigU3kRmoD6jrKqY=",
+        "lastModified": 1780450122,
+        "narHash": "sha256-jfCpF+xYRN8IRJ/8JZmNhyBVB20kp+zJ0iyMUU+Q8lw=",
         "ref": "refs/heads/main",
-        "rev": "df6a7c411cbfa80579128e2cf1585e2d6a41b925",
-        "revCount": 27,
+        "rev": "d696fa935f7c9488488db97e91a77130258b24ee",
+        "revCount": 28,
         "type": "git",
         "url": "ssh://git@github.com/parallaxisjones/nix-secrets.git"
       },

--- a/hosts/nixos/configuration.nix
+++ b/hosts/nixos/configuration.nix
@@ -17,6 +17,8 @@
       ../../modules/nixos/secrets.nix
       # NAS SMB/CIFS mounts
       ../../modules/nixos/nas-mounts.nix
+      # Homelab service stack (torrent + *arr + Jellyfin + Caddy reverse proxy)
+      ../../modules/nixos/homelab
     ];
 
   # Bootloader.

--- a/justfile
+++ b/justfile
@@ -1,0 +1,31 @@
+# Convenience targets for this flake.
+# Run `just` to list, `just deploy` to push the nixos host config from the laptop.
+
+# Tailnet (or LAN) hostname of the always-on NixOS box.
+nixos_host := "nixos"
+
+# The nixosConfigurations attr is keyed by system string (see flake.nix),
+# so the desktop/server host is `.#x86_64-linux`, NOT `.#nixos`.
+nixos_attr := "x86_64-linux"
+
+default:
+    @just --list
+
+# Build + switch the NixOS host remotely over SSH. Builds ON the server
+# (--build-host) since a darwin laptop can't build Linux derivations locally.
+deploy host=nixos_host:
+    nixos-rebuild switch \
+      --flake .#{{nixos_attr}} \
+      --target-host parallaxis@{{host}} \
+      --build-host parallaxis@{{host}} \
+      --use-remote-sudo
+
+# Dry-run: build the host config remotely without switching.
+deploy-dry host=nixos_host:
+    nixos-rebuild build \
+      --flake .#{{nixos_attr}} \
+      --build-host parallaxis@{{host}}
+
+# Evaluate the host config locally (no build) — fast syntax/type check.
+check:
+    nix eval .#nixosConfigurations.{{nixos_attr}}.config.system.build.toplevel.drvPath

--- a/modules/nixos/homelab/arr.nix
+++ b/modules/nixos/homelab/arr.nix
@@ -1,4 +1,4 @@
-{ ... }:
+_:
 
 # *arr automation, as native NixOS services (no containers needed — they run on
 # the host network and reach qBittorrent's WebUI at 127.0.0.1:8080).
@@ -17,15 +17,17 @@
 #   - Sonarr/Radarr: add qBittorrent download client at 127.0.0.1:8080
 #   - root folders: /mnt/nas/media/tv (Sonarr), /mnt/nas/media/movies (Radarr)
 {
-  services.prowlarr.enable = true;
+  services = {
+    prowlarr.enable = true;
 
-  services.sonarr = {
-    enable = true;
-    group = "media";
-  };
+    sonarr = {
+      enable = true;
+      group = "media";
+    };
 
-  services.radarr = {
-    enable = true;
-    group = "media";
+    radarr = {
+      enable = true;
+      group = "media";
+    };
   };
 }

--- a/modules/nixos/homelab/arr.nix
+++ b/modules/nixos/homelab/arr.nix
@@ -1,0 +1,31 @@
+{ ... }:
+
+# *arr automation, as native NixOS services (no containers needed — they run on
+# the host network and reach qBittorrent's WebUI at 127.0.0.1:8080).
+#
+#   Prowlarr -> manages indexers, feeds Sonarr/Radarr
+#   Sonarr   -> TV
+#   Radarr   -> movies
+#
+# Sonarr/Radarr run with primary group `media` so they can read completed
+# downloads under /var/lib/torrents and write imports to /mnt/nas/media (the NAS
+# media share is forced to gid=media in nas-mounts.nix). Prowlarr only talks to
+# indexers, so it needs no filesystem access and keeps its default DynamicUser.
+#
+# Post-deploy app config (one-time, in each web UI):
+#   - set the URL base to /prowlarr, /sonarr, /radarr to match the Caddy paths
+#   - Sonarr/Radarr: add qBittorrent download client at 127.0.0.1:8080
+#   - root folders: /mnt/nas/media/tv (Sonarr), /mnt/nas/media/movies (Radarr)
+{
+  services.prowlarr.enable = true;
+
+  services.sonarr = {
+    enable = true;
+    group = "media";
+  };
+
+  services.radarr = {
+    enable = true;
+    group = "media";
+  };
+}

--- a/modules/nixos/homelab/default.nix
+++ b/modules/nixos/homelab/default.nix
@@ -14,14 +14,16 @@
     ./proxy.nix
   ];
 
-  # Shared group for everything that touches the download-staging dir or the
-  # NAS media library. Members get group read/write; setgid dirs (storage.nix)
-  # propagate the group so files created by one service are usable by another.
-  # Fixed gid so it matches the gid forced on the CIFS media mount (nas-mounts.nix).
-  users.groups.media.gid = 985;
+  users = {
+    # Shared group for everything that touches the download-staging dir or the
+    # NAS media library. Members get group read/write; setgid dirs (storage.nix)
+    # propagate the group so files created by one service are usable by another.
+    # Fixed gid so it matches the gid forced on the CIFS media mount (nas-mounts.nix).
+    groups.media.gid = 985;
 
-  # Let the primary admin browse/manage media and downloads from a shell.
-  users.users.${user}.extraGroups = [ "media" ];
+    # Let the primary admin browse/manage media and downloads from a shell.
+    users.${user}.extraGroups = [ "media" ];
+  };
 
   # All homelab containers run on the Docker daemon already enabled in
   # hosts/nixos/configuration.nix.

--- a/modules/nixos/homelab/default.nix
+++ b/modules/nixos/homelab/default.nix
@@ -1,0 +1,29 @@
+{ user, ... }:
+
+# Homelab service stack: torrenting (gluetun + qBittorrent), the *arr
+# automation suite, a Jellyfin media server, and a Caddy reverse proxy that
+# exposes everything privately over the tailnet. See docs/ and the plan for the
+# overall design; each concern lives in its own file below.
+{
+  imports = [
+    ./storage.nix
+    ./vpn.nix
+    ./torrent.nix
+    ./arr.nix
+    ./jellyfin.nix
+    ./proxy.nix
+  ];
+
+  # Shared group for everything that touches the download-staging dir or the
+  # NAS media library. Members get group read/write; setgid dirs (storage.nix)
+  # propagate the group so files created by one service are usable by another.
+  # Fixed gid so it matches the gid forced on the CIFS media mount (nas-mounts.nix).
+  users.groups.media.gid = 985;
+
+  # Let the primary admin browse/manage media and downloads from a shell.
+  users.users.${user}.extraGroups = [ "media" ];
+
+  # All homelab containers run on the Docker daemon already enabled in
+  # hosts/nixos/configuration.nix.
+  virtualisation.oci-containers.backend = "docker";
+}

--- a/modules/nixos/homelab/jellyfin.nix
+++ b/modules/nixos/homelab/jellyfin.nix
@@ -1,0 +1,22 @@
+{ ... }:
+
+# Jellyfin media server. Runs with primary group `media` for read access to the
+# NAS library (/mnt/nas/media). Add the library folders in the Jellyfin setup
+# wizard (e.g. /mnt/nas/media/movies, /mnt/nas/media/tv) and set the base URL to
+# /jellyfin so it works behind the Caddy path prefix.
+{
+  services.jellyfin = {
+    enable = true;
+    group = "media";
+  };
+
+  # Hardware (VAAPI) transcoding is left OFF until a render node is confirmed on
+  # this host: desktop Ryzen chips have no iGPU, though the old desktop config
+  # referenced an amdgpu discrete card. CPU transcoding (and direct-play) work
+  # without it. To enable once `/dev/dri/renderD128` exists on the box:
+  #
+  #   hardware.graphics.enable = true;
+  #   users.users.jellyfin.extraGroups = [ "render" "video" ];
+  #
+  # then select VAAPI (/dev/dri/renderD128) in Jellyfin's Playback settings.
+}

--- a/modules/nixos/homelab/jellyfin.nix
+++ b/modules/nixos/homelab/jellyfin.nix
@@ -1,4 +1,4 @@
-{ ... }:
+_:
 
 # Jellyfin media server. Runs with primary group `media` for read access to the
 # NAS library (/mnt/nas/media). Add the library folders in the Jellyfin setup

--- a/modules/nixos/homelab/proxy.nix
+++ b/modules/nixos/homelab/proxy.nix
@@ -20,57 +20,61 @@ let
   certDir = "/var/lib/caddy/tailscale";
 in
 {
-  # Permit the caddy user to obtain tailnet certs from the tailscale daemon.
-  services.tailscale.permitCertUid = "caddy";
+  systemd = {
+    tmpfiles.rules = [
+      "d ${certDir} 0750 caddy caddy -"
+    ];
 
-  systemd.tmpfiles.rules = [
-    "d ${certDir} 0750 caddy caddy -"
-  ];
+    # Fetch/refresh the cert before Caddy starts, and weekly thereafter.
+    services.tailscale-cert = {
+      description = "Provision tailnet TLS certificate for Caddy";
+      after = [ "tailscaled.service" "network-online.target" ];
+      wants = [ "network-online.target" ];
+      before = [ "caddy.service" ];
+      wantedBy = [ "caddy.service" ];
+      serviceConfig = {
+        Type = "oneshot";
+        User = "caddy";
+        Group = "caddy";
+        ExecStart = ''
+          ${pkgs.tailscale}/bin/tailscale cert \
+            --cert-file ${certDir}/${host}.crt \
+            --key-file ${certDir}/${host}.key \
+            ${host}
+        '';
+      };
+    };
 
-  # Fetch/refresh the cert before Caddy starts, and weekly thereafter.
-  systemd.services.tailscale-cert = {
-    description = "Provision tailnet TLS certificate for Caddy";
-    after = [ "tailscaled.service" "network-online.target" ];
-    wants = [ "network-online.target" ];
-    before = [ "caddy.service" ];
-    wantedBy = [ "caddy.service" ];
-    serviceConfig = {
-      Type = "oneshot";
-      User = "caddy";
-      Group = "caddy";
-      ExecStart = ''
-        ${pkgs.tailscale}/bin/tailscale cert \
-          --cert-file ${certDir}/${host}.crt \
-          --key-file ${certDir}/${host}.key \
-          ${host}
-      '';
+    timers.tailscale-cert = {
+      wantedBy = [ "timers.target" ];
+      timerConfig = {
+        OnCalendar = "weekly";
+        Persistent = true;
+      };
     };
   };
 
-  systemd.timers.tailscale-cert = {
-    wantedBy = [ "timers.target" ];
-    timerConfig = {
-      OnCalendar = "weekly";
-      Persistent = true;
-    };
-  };
+  services = {
+    # Permit the caddy user to obtain tailnet certs from the tailscale daemon.
+    tailscale.permitCertUid = "caddy";
 
-  services.caddy = {
-    enable = true;
-    virtualHosts."${host}" = {
-      extraConfig = ''
-        tls ${certDir}/${host}.crt ${certDir}/${host}.key
+    caddy = {
+      enable = true;
+      virtualHosts."${host}" = {
+        extraConfig = ''
+          tls ${certDir}/${host}.crt ${certDir}/${host}.key
 
-        handle /jellyfin/* { reverse_proxy 127.0.0.1:8096 }
-        handle /prowlarr/* { reverse_proxy 127.0.0.1:9696 }
-        handle /sonarr/*   { reverse_proxy 127.0.0.1:8989 }
-        handle /radarr/*   { reverse_proxy 127.0.0.1:7878 }
+          handle /jellyfin/* { reverse_proxy 127.0.0.1:8096 }
+          handle /prowlarr/* { reverse_proxy 127.0.0.1:9696 }
+          handle /sonarr/*   { reverse_proxy 127.0.0.1:8989 }
+          handle /radarr/*   { reverse_proxy 127.0.0.1:7878 }
 
-        # qBittorrent has no URL-base support, so it owns the site root.
-        handle {
-          reverse_proxy 127.0.0.1:8080
-        }
-      '';
+          # qBittorrent has no URL-base support, so it owns the site root.
+          handle {
+            reverse_proxy 127.0.0.1:8080
+          }
+        '';
+      };
     };
   };
 

--- a/modules/nixos/homelab/proxy.nix
+++ b/modules/nixos/homelab/proxy.nix
@@ -1,4 +1,4 @@
-{ config, pkgs, ... }:
+{ pkgs, ... }:
 
 # Caddy reverse proxy fronting every service under a single tailnet hostname,
 # with real TLS certs issued for the tailnet name. Tailnet-only: nothing here is

--- a/modules/nixos/homelab/proxy.nix
+++ b/modules/nixos/homelab/proxy.nix
@@ -1,0 +1,81 @@
+{ config, pkgs, ... }:
+
+# Caddy reverse proxy fronting every service under a single tailnet hostname,
+# with real TLS certs issued for the tailnet name. Tailnet-only: nothing here is
+# meant to face the public internet.
+#
+# Routing is path-based under one host (tailnet certs are per-machine, not
+# wildcard). The *arr apps and Jellyfin support a configurable URL base, so they
+# live under /prowlarr, /sonarr, /radarr, /jellyfin — set each app's base URL to
+# match (see the per-service modules). qBittorrent has NO subpath support
+# upstream, so it is served at the site root (/).
+#
+# TLS approach: a oneshot mints/refreshes the cert via `tailscale cert` and Caddy
+# serves it from files. This requires MagicDNS + HTTPS certificates enabled in
+# the Tailscale admin console (one-time). The caddy-tailscale plugin is a
+# hands-off alternative but needs a custom Caddy build (vendor hash), so we use
+# the file-based approach here.
+let
+  host = "nixos.tail9fed5f.ts.net";
+  certDir = "/var/lib/caddy/tailscale";
+in
+{
+  # Permit the caddy user to obtain tailnet certs from the tailscale daemon.
+  services.tailscale.permitCertUid = "caddy";
+
+  systemd.tmpfiles.rules = [
+    "d ${certDir} 0750 caddy caddy -"
+  ];
+
+  # Fetch/refresh the cert before Caddy starts, and weekly thereafter.
+  systemd.services.tailscale-cert = {
+    description = "Provision tailnet TLS certificate for Caddy";
+    after = [ "tailscaled.service" "network-online.target" ];
+    wants = [ "network-online.target" ];
+    before = [ "caddy.service" ];
+    wantedBy = [ "caddy.service" ];
+    serviceConfig = {
+      Type = "oneshot";
+      User = "caddy";
+      Group = "caddy";
+      ExecStart = ''
+        ${pkgs.tailscale}/bin/tailscale cert \
+          --cert-file ${certDir}/${host}.crt \
+          --key-file ${certDir}/${host}.key \
+          ${host}
+      '';
+    };
+  };
+
+  systemd.timers.tailscale-cert = {
+    wantedBy = [ "timers.target" ];
+    timerConfig = {
+      OnCalendar = "weekly";
+      Persistent = true;
+    };
+  };
+
+  services.caddy = {
+    enable = true;
+    virtualHosts."${host}" = {
+      extraConfig = ''
+        tls ${certDir}/${host}.crt ${certDir}/${host}.key
+
+        handle /jellyfin/* { reverse_proxy 127.0.0.1:8096 }
+        handle /prowlarr/* { reverse_proxy 127.0.0.1:9696 }
+        handle /sonarr/*   { reverse_proxy 127.0.0.1:8989 }
+        handle /radarr/*   { reverse_proxy 127.0.0.1:7878 }
+
+        # qBittorrent has no URL-base support, so it owns the site root.
+        handle {
+          reverse_proxy 127.0.0.1:8080
+        }
+      '';
+    };
+  };
+
+  # NOTE: 443 is already open in the firewall (hosts/nixos/configuration.nix) and
+  # tailscale0 is a trusted interface. Caddy binds all interfaces by default, so
+  # the proxy is reachable on the LAN too; to make it strictly tailnet-only,
+  # bind Caddy to the tailscale IP and drop 443 from allowedTCPPorts (follow-up).
+}

--- a/modules/nixos/homelab/storage.nix
+++ b/modules/nixos/homelab/storage.nix
@@ -1,4 +1,4 @@
-{ ... }:
+_:
 
 # Local download staging. Active downloads + seeding live on the fast local
 # ext4 root; completed media is imported (copied) to the NAS by the *arr stack.

--- a/modules/nixos/homelab/storage.nix
+++ b/modules/nixos/homelab/storage.nix
@@ -1,0 +1,24 @@
+{ ... }:
+
+# Local download staging. Active downloads + seeding live on the fast local
+# ext4 root; completed media is imported (copied) to the NAS by the *arr stack.
+{
+  # Fixed-uid service account the qBittorrent container runs as (PUID/PGID in
+  # torrent.nix). A fixed uid keeps download ownership stable across rebuilds and
+  # avoids depending on the dynamically-allocated uid of the login user.
+  users.users.qbittorrent = {
+    isSystemUser = true;
+    uid = 8080;
+    group = "media";
+    description = "qBittorrent container service account";
+  };
+
+  # setgid (leading 2) so files/dirs created under the staging tree inherit the
+  # shared `media` group and the *arr services (also in `media`) can import them.
+  systemd.tmpfiles.rules = [
+    "d /var/lib/torrents            2775 qbittorrent media -"
+    "d /var/lib/torrents/incomplete 2775 qbittorrent media -"
+    "d /var/lib/torrents/complete   2775 qbittorrent media -"
+    "d /var/lib/qbittorrent         0750 qbittorrent media -"
+  ];
+}

--- a/modules/nixos/homelab/torrent.nix
+++ b/modules/nixos/homelab/torrent.nix
@@ -1,0 +1,34 @@
+{ config, ... }:
+
+# qBittorrent, pinned into gluetun's network namespace so every byte it sends
+# goes through the VPN (killswitch inherited from gluetun). It has no `ports` of
+# its own — the WebUI is published by gluetun (vpn.nix) on 127.0.0.1:8080.
+#
+# The download tree is bind-mounted at the SAME path inside the container as on
+# the host (/var/lib/torrents). That way the path qBittorrent reports to Sonarr/
+# Radarr matches what those native services see, so no remote-path-mapping is
+# needed. Set qBittorrent's default save path to /var/lib/torrents/complete on
+# first run. (qBittorrent has no URL-base support, so Caddy serves it at the site
+# root rather than a subpath — see proxy.nix.)
+{
+  virtualisation.oci-containers.containers.qbittorrent = {
+    image = "lscr.io/linuxserver/qbittorrent:latest";
+    dependsOn = [ "gluetun" ];
+
+    # Share gluetun's netns -> all traffic via the VPN. (Cannot combine with `ports`.)
+    extraOptions = [ "--network=container:gluetun" ];
+
+    environment = {
+      PUID = "8080"; # qbittorrent service user (storage.nix)
+      PGID = "985"; # media group (default.nix)
+      TZ = config.time.timeZone;
+      UMASK = "002"; # group-writable so the *arr stack can import
+      WEBUI_PORT = "8080";
+    };
+
+    volumes = [
+      "/var/lib/qbittorrent:/config"
+      "/var/lib/torrents:/var/lib/torrents"
+    ];
+  };
+}

--- a/modules/nixos/homelab/vpn.nix
+++ b/modules/nixos/homelab/vpn.nix
@@ -1,48 +1,132 @@
 { config, ... }:
 
 # gluetun: a ProtonVPN WireGuard tunnel with a built-in killswitch. qBittorrent
-# shares this container's network namespace (torrent.nix), so all torrent traffic
-# exits through the VPN and, if the tunnel drops, qBittorrent has no route out.
+# shares this container's network namespace (see torrent.nix:
+# `--network=container:gluetun`), so ALL of qBittorrent's traffic exits through
+# the VPN and, if the tunnel drops, qBittorrent has no route out at all. Nothing
+# else on the host uses this tunnel.
 #
-# The WireGuard private key is provided by agenix as an env file containing
-# `WIREGUARD_PRIVATE_KEY=...` (see modules/nixos/secrets.nix). Add
-# protonvpn-wireguard.age to the nix-secrets repo before deploying, or gluetun
-# will fail to start.
+# ── Secret ────────────────────────────────────────────────────────────────────
+# The WireGuard private key is NOT in this file. It's an agenix secret
+# (modules/nixos/secrets.nix -> protonvpn-wireguard.age in the nix-secrets repo),
+# decrypted at activation to an env file whose single line is:
+#     WIREGUARD_PRIVATE_KEY=<key from the Proton config's [Interface] PrivateKey>
+# gluetun reads it via `environmentFiles` below. If the .age file is missing from
+# the pinned `secrets` input, gluetun fails to start.
+#
+# To rotate the key: regenerate the WireGuard config in the Proton dashboard,
+# re-encrypt protonvpn-wireguard.age with the new key, push nix-secrets, then
+# `nix flake update secrets` + commit so this host picks it up.
+#
+# ── Where the rest of the settings come from ───────────────────────────────────
+# Everything except the private key is non-secret and lives here as plain env.
+# The values map to lines in the Proton WireGuard config you download:
+#   [Interface] Address = 10.2.0.2/32  -> WIREGUARD_ADDRESSES (IPv4 part only)
+#   [Interface] PrivateKey = ...       -> the agenix secret (above)
+# gluetun supplies the server endpoint/peer key itself from its built-in server
+# list, so we do NOT copy the [Peer] section — we just tell it which servers to
+# pick via SERVER_COUNTRIES / FREE_ONLY.
+#
+# ── Free vs paid ───────────────────────────────────────────────────────────────
+# This host currently runs a FREE Proton account (active block below). Free tier:
+#   * only free servers authenticate the key  -> FREE_ONLY = "on"
+#   * no WireGuard port forwarding             -> VPN_PORT_FORWARDING = "off"
+#   * limited countries (US/NL/JP/… , varies)  -> SERVER_COUNTRIES = "United States"
+# Port forwarding being off means worse seeding/connectability (no inbound peers),
+# but downloads and outbound connections work fine.
+#
+# To switch to a PAID plan later: comment out the FREE block, uncomment the PAID
+# block, set the server location you want, redeploy, and (if you enable port
+# forwarding) wire qBittorrent's listening port to gluetun's forwarded port — see
+# the note at the bottom of the PAID block.
+#
+# Reference: https://github.com/qdm12/gluetun-wiki/blob/main/setup/providers/protonvpn.md
 let
   qbWebUiPort = 8080;
 in
 {
   virtualisation.oci-containers.containers.gluetun = {
+    # Pin to the v3 major tag. Bump deliberately; gluetun's embedded server list
+    # changes between releases (see free-tier caveat below).
     image = "qmcgaw/gluetun:v3";
 
     environment = {
+      # ── Provider (same for free and paid) ──
       VPN_SERVICE_PROVIDER = "protonvpn";
       VPN_TYPE = "wireguard";
-      # Free Proton account: restrict to free-tier servers (FREE_ONLY) and keep
-      # port forwarding off — free Proton does not support WireGuard PF.
-      FREE_ONLY = "on";
-      VPN_PORT_FORWARDING = "off";
-      # Free servers exist in the US (the downloaded config was US-FREE); this
-      # pairs with FREE_ONLY. Upgrade to a paid plan to use other countries + PF.
-      SERVER_COUNTRIES = "United States";
-      # Client interface address from the Proton config's [Interface] Address line
-      # (IPv4 only — avoids IPv6 routing issues inside Docker). Without this,
-      # the tunnel handshakes but no traffic routes (the i/o-timeout loop we hit).
-      # If a regenerated config assigns a different address, update this value.
+
+      # Client interface address from the Proton config's [Interface] Address line.
+      # IPv4 only on purpose — the Docker bridge has no IPv6 by default, and adding
+      # the IPv6 address makes gluetun try to configure a route it can't use.
+      # WITHOUT this, the tunnel handshakes but no traffic routes (DNS i/o-timeout
+      # loop -> gluetun marks itself unhealthy and rotates servers forever).
+      # Update if a regenerated config assigns a different address.
       WIREGUARD_ADDRESSES = "10.2.0.2/32";
+
+      # ─────────────────────────────────────────────────────────────────────────
+      # FREE tier (ACTIVE). Free Proton WireGuard keys only authenticate against
+      # free servers, so we must filter to them; otherwise gluetun picks a paid
+      # server, the handshake "completes" silently, and every request times out.
+      FREE_ONLY = "on";
+      VPN_PORT_FORWARDING = "off"; # not available on free
+      # Free servers are concentrated in a few countries (the downloaded config
+      # was US-FREE). Keep this to a country that actually has free servers.
+      SERVER_COUNTRIES = "United States";
+      # ─────────────────────────────────────────────────────────────────────────
+
+      # ── PAID tier (commented out — swap in when you upgrade) ──
+      # 1. Comment out the three FREE lines above (FREE_ONLY / VPN_PORT_FORWARDING
+      #    / SERVER_COUNTRIES).
+      # 2. Uncomment the block below and pick your exit location.
+      #
+      # # Use any server (drop FREE_ONLY entirely on paid).
+      # # Choose ONE location selector — country is simplest:
+      # SERVER_COUNTRIES = "Netherlands";   # e.g. NL for good P2P + PF
+      # # SERVER_CITIES   = "Amsterdam";
+      # # SERVER_HOSTNAMES = "node-nl-01.protonvpn.net"; # pin an exact server
+      #
+      # # Port forwarding: paid Proton supports it over WireGuard. gluetun will
+      # # request a port and expose it on its control server (:8000). This greatly
+      # # improves seeding because peers can reach you inbound.
+      # VPN_PORT_FORWARDING = "on";
+      # VPN_PORT_FORWARDING_PROVIDER = "protonvpn";
+      # # gluetun writes the negotiated port here; useful for scripting qBittorrent.
+      # VPN_PORT_FORWARDING_STATUS_FILE = "/tmp/gluetun/forwarded_port";
+      #
+      # # NOTE: the forwarded port is dynamic, so qBittorrent's "listening port"
+      # # must be set to whatever gluetun negotiated, or inbound peers won't reach
+      # # you. Options once on paid:
+      # #   - read /tmp/gluetun/forwarded_port and set it in qBittorrent manually, or
+      # #   - add a small sidecar/script that polls gluetun's control API
+      # #     (http://127.0.0.1:8000/v1/openvpn/portforwarded) and pushes the port
+      # #     into qBittorrent via its WebUI API. (Left as a follow-up.)
+
       TZ = config.time.timeZone;
     };
 
-    # Holds WIREGUARD_PRIVATE_KEY=... (decrypted by agenix at activation).
+    # Single line: WIREGUARD_PRIVATE_KEY=... (decrypted by agenix at activation).
     environmentFiles = [ config.age.secrets."protonvpn-wireguard".path ];
 
     # gluetun publishes qBittorrent's WebUI (qbit lives in this netns). Bound to
-    # localhost so only the Caddy reverse proxy can reach it.
+    # localhost so only the Caddy reverse proxy can reach it. On PAID with port
+    # forwarding you may also want to publish gluetun's control server to read the
+    # forwarded port, e.g. add "127.0.0.1:8000:8000/tcp".
     ports = [ "127.0.0.1:${toString qbWebUiPort}:${toString qbWebUiPort}" ];
 
     extraOptions = [
+      # WireGuard needs NET_ADMIN to bring up the wg interface, and the tun device
+      # to create the tunnel. Both are required regardless of tier.
       "--cap-add=NET_ADMIN"
       "--device=/dev/net/tun:/dev/net/tun"
     ];
   };
+
+  # ── Free-tier server caveat ────────────────────────────────────────────────
+  # gluetun ships an embedded server list. A known issue strips free Proton
+  # servers from that list on some releases / after the server-data updater runs
+  # (https://github.com/qdm12/gluetun/issues/2598). Symptom: instead of the
+  # i/o-timeout loop you get "no server found" with FREE_ONLY=on. If that happens,
+  # pin a known-good free server with SERVER_HOSTNAMES instead of FREE_ONLY, or
+  # move to a paid plan. (We do NOT enable gluetun's periodic updater here, so the
+  # baked-in list stays put.)
 }

--- a/modules/nixos/homelab/vpn.nix
+++ b/modules/nixos/homelab/vpn.nix
@@ -18,16 +18,22 @@ in
     environment = {
       VPN_SERVICE_PROVIDER = "protonvpn";
       VPN_TYPE = "wireguard";
-      # ProtonVPN supports port forwarding (paid). Improves seeding/connectability.
-      VPN_PORT_FORWARDING = "on";
-      VPN_PORT_FORWARDING_PROVIDER = "protonvpn";
-      # Exit location. ProtonVPN port forwarding requires a P2P-enabled server;
-      # adjust to taste once the tunnel is verified.
-      SERVER_COUNTRIES = "Netherlands";
+      # Free Proton account: restrict to free-tier servers (FREE_ONLY) and keep
+      # port forwarding off — free Proton does not support WireGuard PF.
+      FREE_ONLY = "on";
+      VPN_PORT_FORWARDING = "off";
+      # Free servers exist in the US (the downloaded config was US-FREE); this
+      # pairs with FREE_ONLY. Upgrade to a paid plan to use other countries + PF.
+      SERVER_COUNTRIES = "United States";
+      # Client interface address from the Proton config's [Interface] Address line
+      # (IPv4 only — avoids IPv6 routing issues inside Docker). Without this,
+      # the tunnel handshakes but no traffic routes (the i/o-timeout loop we hit).
+      # If a regenerated config assigns a different address, update this value.
+      WIREGUARD_ADDRESSES = "10.2.0.2/32";
       TZ = config.time.timeZone;
     };
 
-    # Holds WIREGUARD_PRIVATE_KEY=... (and optionally WIREGUARD_ADDRESSES=...).
+    # Holds WIREGUARD_PRIVATE_KEY=... (decrypted by agenix at activation).
     environmentFiles = [ config.age.secrets."protonvpn-wireguard".path ];
 
     # gluetun publishes qBittorrent's WebUI (qbit lives in this netns). Bound to

--- a/modules/nixos/homelab/vpn.nix
+++ b/modules/nixos/homelab/vpn.nix
@@ -63,12 +63,23 @@ in
       # Update if a regenerated config assigns a different address.
       WIREGUARD_ADDRESSES = "10.2.0.2/32";
 
+      # gluetun's built-in DNS-over-TLS (to Cloudflare, over the tunnel) is one of
+      # the first things to fail on a congested free server — it shows up as
+      # "lookup <host>: i/o timeout" in the healthcheck and triggers a reconnect
+      # loop. Turn DoT off so DNS uses the VPN's resolver instead. (On a paid plan
+      # the tunnel is stable enough to flip this back to "on" if you want DoT.)
+      DOT = "off";
+
       # ─────────────────────────────────────────────────────────────────────────
       # FREE tier (ACTIVE). Free Proton WireGuard keys only authenticate against
       # free servers, so we must filter to them; otherwise gluetun picks a paid
       # server, the handshake "completes" silently, and every request times out.
       FREE_ONLY = "on";
       VPN_PORT_FORWARDING = "off"; # not available on free
+      # Free servers are slow/oversubscribed; give the tunnel more grace before
+      # the healthcheck tears it down and reconnects. Too-aggressive restarts
+      # churn the connection and stop qBittorrent from holding peers/DHT.
+      HEALTH_VPN_DURATION_INITIAL = "30s";
       # Free servers are concentrated in a few countries (the downloaded config
       # was US-FREE). Keep this to a country that actually has free servers.
       SERVER_COUNTRIES = "United States";

--- a/modules/nixos/homelab/vpn.nix
+++ b/modules/nixos/homelab/vpn.nix
@@ -28,17 +28,15 @@
 # pick via SERVER_COUNTRIES / FREE_ONLY.
 #
 # ── Free vs paid ───────────────────────────────────────────────────────────────
-# This host currently runs a FREE Proton account (active block below). Free tier:
-#   * only free servers authenticate the key  -> FREE_ONLY = "on"
-#   * no WireGuard port forwarding             -> VPN_PORT_FORWARDING = "off"
-#   * limited countries (US/NL/JP/… , varies)  -> SERVER_COUNTRIES = "United States"
-# Port forwarding being off means worse seeding/connectability (no inbound peers),
-# but downloads and outbound connections work fine.
+# This host runs a PAID Proton account (active block below). Paid tier:
+#   * any server authenticates the key   -> no FREE_ONLY filter
+#   * WireGuard port forwarding available -> VPN_PORT_FORWARDING = "on"
+#   * all countries available             -> SERVER_COUNTRIES = "Netherlands" (good P2P)
+# Port forwarding lets inbound peers reach you, which materially improves seeding
+# and connectability vs the old free tier.
 #
-# To switch to a PAID plan later: comment out the FREE block, uncomment the PAID
-# block, set the server location you want, redeploy, and (if you enable port
-# forwarding) wire qBittorrent's listening port to gluetun's forwarded port — see
-# the note at the bottom of the PAID block.
+# To revert to FREE later: comment out the PAID block, uncomment the FREE block,
+# and redeploy. (The FREE block is preserved below for reference.)
 #
 # Reference: https://github.com/qdm12/gluetun-wiki/blob/main/setup/providers/protonvpn.md
 let
@@ -63,54 +61,46 @@ in
       # Update if a regenerated config assigns a different address.
       WIREGUARD_ADDRESSES = "10.2.0.2/32";
 
-      # gluetun's built-in DNS-over-TLS (to Cloudflare, over the tunnel) is one of
-      # the first things to fail on a congested free server — it shows up as
-      # "lookup <host>: i/o timeout" in the healthcheck and triggers a reconnect
-      # loop. Turn DoT off so DNS uses the VPN's resolver instead. (On a paid plan
-      # the tunnel is stable enough to flip this back to "on" if you want DoT.)
-      DOT = "off";
+      # On paid the tunnel is stable, so we use gluetun's built-in DNS-over-TLS
+      # (to Cloudflare, over the tunnel). On the old free tier this had to be off
+      # because congested servers made DoT the first thing to fail (i/o-timeout
+      # reconnect loop). Flip back to "off" if you ever see DNS instability.
+      DOT = "on";
 
       # ─────────────────────────────────────────────────────────────────────────
-      # FREE tier (ACTIVE). Free Proton WireGuard keys only authenticate against
-      # free servers, so we must filter to them; otherwise gluetun picks a paid
-      # server, the handshake "completes" silently, and every request times out.
-      FREE_ONLY = "on";
-      VPN_PORT_FORWARDING = "off"; # not available on free
-      # Free servers are slow/oversubscribed; give the tunnel more grace before
-      # the healthcheck tears it down and reconnects. Too-aggressive restarts
-      # churn the connection and stop qBittorrent from holding peers/DHT.
-      HEALTH_VPN_DURATION_INITIAL = "30s";
-      # Free servers are concentrated in a few countries (the downloaded config
-      # was US-FREE). Keep this to a country that actually has free servers.
-      SERVER_COUNTRIES = "United States";
-      # ─────────────────────────────────────────────────────────────────────────
+      # PAID tier (ACTIVE). Any server authenticates the key, so no FREE_ONLY
+      # filter. Choose ONE location selector — country is simplest. NL has good
+      # P2P throughput and supports port forwarding.
+      SERVER_COUNTRIES = "Netherlands";
+      # SERVER_CITIES    = "Amsterdam";
+      # SERVER_HOSTNAMES = "node-nl-01.protonvpn.net"; # pin an exact server
 
-      # ── PAID tier (commented out — swap in when you upgrade) ──
-      # 1. Comment out the three FREE lines above (FREE_ONLY / VPN_PORT_FORWARDING
-      #    / SERVER_COUNTRIES).
-      # 2. Uncomment the block below and pick your exit location.
+      # Port forwarding: paid Proton supports it over WireGuard. gluetun requests
+      # a port and exposes it on its control server (:8000). Improves seeding
+      # because peers can reach you inbound.
+      VPN_PORT_FORWARDING = "on";
+      VPN_PORT_FORWARDING_PROVIDER = "protonvpn";
+      # gluetun writes the negotiated port here; useful for scripting qBittorrent.
+      VPN_PORT_FORWARDING_STATUS_FILE = "/tmp/gluetun/forwarded_port";
+      # ─────────────────────────────────────────────────────────────────────────
       #
-      # # Use any server (drop FREE_ONLY entirely on paid).
-      # # Choose ONE location selector — country is simplest:
-      # SERVER_COUNTRIES = "Netherlands";   # e.g. NL for good P2P + PF
-      # # SERVER_CITIES   = "Amsterdam";
-      # # SERVER_HOSTNAMES = "node-nl-01.protonvpn.net"; # pin an exact server
+      # NOTE: the forwarded port is dynamic, so qBittorrent's "listening port"
+      # must be set to whatever gluetun negotiated, or inbound peers won't reach
+      # you. Options:
+      #   - read /tmp/gluetun/forwarded_port and set it in qBittorrent manually, or
+      #   - add a small sidecar/script that polls gluetun's control API
+      #     (http://127.0.0.1:8000/v1/openvpn/portforwarded) and pushes the port
+      #     into qBittorrent via its WebUI API. (Left as a follow-up.)
+
+      # ── FREE tier (commented out — swap back if you ever downgrade) ──
+      # 1. Comment out the PAID lines above (SERVER_COUNTRIES / the three
+      #    VPN_PORT_FORWARDING* lines), and set DOT = "off".
+      # 2. Uncomment the block below.
       #
-      # # Port forwarding: paid Proton supports it over WireGuard. gluetun will
-      # # request a port and expose it on its control server (:8000). This greatly
-      # # improves seeding because peers can reach you inbound.
-      # VPN_PORT_FORWARDING = "on";
-      # VPN_PORT_FORWARDING_PROVIDER = "protonvpn";
-      # # gluetun writes the negotiated port here; useful for scripting qBittorrent.
-      # VPN_PORT_FORWARDING_STATUS_FILE = "/tmp/gluetun/forwarded_port";
-      #
-      # # NOTE: the forwarded port is dynamic, so qBittorrent's "listening port"
-      # # must be set to whatever gluetun negotiated, or inbound peers won't reach
-      # # you. Options once on paid:
-      # #   - read /tmp/gluetun/forwarded_port and set it in qBittorrent manually, or
-      # #   - add a small sidecar/script that polls gluetun's control API
-      # #     (http://127.0.0.1:8000/v1/openvpn/portforwarded) and pushes the port
-      # #     into qBittorrent via its WebUI API. (Left as a follow-up.)
+      # FREE_ONLY = "on";                      # free keys only auth on free servers
+      # VPN_PORT_FORWARDING = "off";           # not available on free
+      # HEALTH_VPN_DURATION_INITIAL = "30s";   # grace for slow/oversubscribed servers
+      # SERVER_COUNTRIES = "United States";    # free servers cluster in a few countries
 
       TZ = config.time.timeZone;
     };
@@ -122,7 +112,12 @@ in
     # localhost so only the Caddy reverse proxy can reach it. On PAID with port
     # forwarding you may also want to publish gluetun's control server to read the
     # forwarded port, e.g. add "127.0.0.1:8000:8000/tcp".
-    ports = [ "127.0.0.1:${toString qbWebUiPort}:${toString qbWebUiPort}" ];
+    ports = [
+      "127.0.0.1:${toString qbWebUiPort}:${toString qbWebUiPort}"
+      # gluetun control server — read the negotiated forwarded port via
+      # `curl http://127.0.0.1:8000/v1/openvpn/portforwarded`.
+      "127.0.0.1:8000:8000/tcp"
+    ];
 
     extraOptions = [
       # WireGuard needs NET_ADMIN to bring up the wg interface, and the tun device

--- a/modules/nixos/homelab/vpn.nix
+++ b/modules/nixos/homelab/vpn.nix
@@ -89,7 +89,7 @@ in
       # you. Options:
       #   - read /tmp/gluetun/forwarded_port and set it in qBittorrent manually, or
       #   - add a small sidecar/script that polls gluetun's control API
-      #     (http://127.0.0.1:8000/v1/openvpn/portforwarded) and pushes the port
+      #     (http://127.0.0.1:8000/v1/portforward) and pushes the port
       #     into qBittorrent via its WebUI API. (Left as a follow-up.)
 
       # ── FREE tier (commented out — swap back if you ever downgrade) ──
@@ -115,7 +115,7 @@ in
     ports = [
       "127.0.0.1:${toString qbWebUiPort}:${toString qbWebUiPort}"
       # gluetun control server — read the negotiated forwarded port via
-      # `curl http://127.0.0.1:8000/v1/openvpn/portforwarded`.
+      # `curl http://127.0.0.1:8000/v1/portforward`.
       "127.0.0.1:8000:8000/tcp"
     ];
 

--- a/modules/nixos/homelab/vpn.nix
+++ b/modules/nixos/homelab/vpn.nix
@@ -1,0 +1,42 @@
+{ config, ... }:
+
+# gluetun: a ProtonVPN WireGuard tunnel with a built-in killswitch. qBittorrent
+# shares this container's network namespace (torrent.nix), so all torrent traffic
+# exits through the VPN and, if the tunnel drops, qBittorrent has no route out.
+#
+# The WireGuard private key is provided by agenix as an env file containing
+# `WIREGUARD_PRIVATE_KEY=...` (see modules/nixos/secrets.nix). Add
+# protonvpn-wireguard.age to the nix-secrets repo before deploying, or gluetun
+# will fail to start.
+let
+  qbWebUiPort = 8080;
+in
+{
+  virtualisation.oci-containers.containers.gluetun = {
+    image = "qmcgaw/gluetun:v3";
+
+    environment = {
+      VPN_SERVICE_PROVIDER = "protonvpn";
+      VPN_TYPE = "wireguard";
+      # ProtonVPN supports port forwarding (paid). Improves seeding/connectability.
+      VPN_PORT_FORWARDING = "on";
+      VPN_PORT_FORWARDING_PROVIDER = "protonvpn";
+      # Exit location. ProtonVPN port forwarding requires a P2P-enabled server;
+      # adjust to taste once the tunnel is verified.
+      SERVER_COUNTRIES = "Netherlands";
+      TZ = config.time.timeZone;
+    };
+
+    # Holds WIREGUARD_PRIVATE_KEY=... (and optionally WIREGUARD_ADDRESSES=...).
+    environmentFiles = [ config.age.secrets."protonvpn-wireguard".path ];
+
+    # gluetun publishes qBittorrent's WebUI (qbit lives in this netns). Bound to
+    # localhost so only the Caddy reverse proxy can reach it.
+    ports = [ "127.0.0.1:${toString qbWebUiPort}:${toString qbWebUiPort}" ];
+
+    extraOptions = [
+      "--cap-add=NET_ADMIN"
+      "--device=/dev/net/tun:/dev/net/tun"
+    ];
+  };
+}

--- a/modules/nixos/nas-mounts.nix
+++ b/modules/nixos/nas-mounts.nix
@@ -50,8 +50,10 @@ lib.mkIf (config.age.secrets ? "smb-credentials") {
     "/mnt/nas/media" =
       let
         userUid = toString config.users.users.${user}.uid;
-        primaryGroup = config.users.users.${user}.group or user;
-        userGid = toString config.users.groups.${primaryGroup}.gid;
+        # Force the shared `media` group (defined in modules/nixos/homelab) so the
+        # *arr services and Jellyfin — which run with primary group `media` — can
+        # read and write the media library over CIFS.
+        mediaGid = toString config.users.groups.media.gid;
       in
       {
         device = "//nasology.tail9fed5f.ts.net/Media";
@@ -61,7 +63,7 @@ lib.mkIf (config.age.secrets ? "smb-credentials") {
           "_netdev"
           "credentials=${config.age.secrets.smb-credentials.path}"
           "uid=${userUid}"
-          "gid=${userGid}"
+          "gid=${mediaGid}"
           "file_mode=0664"
           "dir_mode=0775"
         ];

--- a/modules/nixos/secrets.nix
+++ b/modules/nixos/secrets.nix
@@ -18,6 +18,18 @@ lib.mkIf (secrets != null) {
         owner = "root";
         group = "root";
       };
+
+      # gluetun reads this as an env file (environmentFiles). The decrypted
+      # contents are a single line: WIREGUARD_PRIVATE_KEY=<key from ProtonVPN>.
+      # Add protonvpn-wireguard.age to the nix-secrets repo before rebuilding.
+      "protonvpn-wireguard" = {
+        symlink = false;
+        path = "/etc/nixos/secrets/protonvpn-wireguard";
+        file = "${secrets}/protonvpn-wireguard.age";
+        mode = "600";
+        owner = "root";
+        group = "root";
+      };
     };
   };
 }


### PR DESCRIPTION
## Context

The `nixos` host was a bare server (Docker + Tailscale + agenix + NAS CIFS mounts, no app services). This adds a base homelab — torrent client, *arr automation, and a media server — all declared in the flake, deployed from the laptop over Tailscale, and reachable privately via a reverse proxy with TLS.

**NixOS-only.** Everything is imported solely by `hosts/nixos/configuration.nix`; the darwin configuration never reaches these files, and the options used (`virtualisation.oci-containers`, `services.{sonarr,radarr,prowlarr,jellyfin,caddy}`) don't exist on nix-darwin anyway.

## What's here

New `modules/nixos/homelab/`:

| File | Role |
|------|------|
| `default.nix` | shared `media` group (gid 985), oci backend = docker |
| `storage.nix` | fixed-uid `qbittorrent` account; setgid `/var/lib/torrents` staging dirs |
| `vpn.nix` | gluetun — ProtonVPN/WireGuard, killswitch, port-forward; publishes qBittorrent WebUI on `127.0.0.1:8080` |
| `torrent.nix` | qBittorrent in gluetun's netns; downloads bind-mounted at identical host/container path (no remote-path-mapping) |
| `arr.nix` | native Prowlarr/Sonarr/Radarr (Sonarr/Radarr in group `media`) |
| `jellyfin.nix` | native Jellyfin (group `media`); VAAPI commented-but-ready |
| `proxy.nix` | Caddy reverse proxy + `tailscale cert` oneshot/timer for tailnet TLS |

Plus: `secrets.nix` gains a `protonvpn-wireguard` agenix entry; `nas-mounts.nix` media share forced to gid=`media` so the *arr stack can write imports; root `justfile` with `deploy`/`deploy-dry`/`check`.

### Routing note
The *arr apps + Jellyfin live under `/sonarr`, `/radarr`, `/prowlarr`, `/jellyfin` (URL base set per-app). qBittorrent has no subpath support upstream, so Caddy serves it at the site **root**.

## Validation

`nix eval` of the host's `system.build.toplevel.drvPath` succeeds — full module tree type-checks, all option names resolve. This does **not** build the Linux closure or exercise runtime (containers/VPN/cert); that happens on first deploy.

## Before deploy works (prerequisites)

1. Add `protonvpn-wireguard.age` (one line `WIREGUARD_PRIVATE_KEY=…`) to the `nix-secrets` repo, then `nix flake update secrets`.
2. Enable MagicDNS + HTTPS certificates in the Tailscale admin console.
3. Run `just deploy-dry` then `just deploy`; configure each app's URL base, download client, and root folders on first run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)