### PR TITLE
Feat/plex server

### DIFF
--- a/justfile
+++ b/justfile
@@ -14,7 +14,7 @@ default:
 # Build + switch the NixOS host remotely over SSH. Builds ON the server
 # (--build-host) since a darwin laptop can't build Linux derivations locally.
 deploy host=nixos_host:
-    nixos-rebuild switch \
+    nix run nixpkgs#nixos-rebuild -- switch \
       --flake .#{{nixos_attr}} \
       --target-host parallaxis@{{host}} \
       --build-host parallaxis@{{host}} \
@@ -22,7 +22,7 @@ deploy host=nixos_host:
 
 # Dry-run: build the host config remotely without switching.
 deploy-dry host=nixos_host:
-    nixos-rebuild build \
+    nix run nixpkgs#nixos-rebuild -- build \
       --flake .#{{nixos_attr}} \
       --build-host parallaxis@{{host}}
 

--- a/modules/darwin/home-manager.nix
+++ b/modules/darwin/home-manager.nix
@@ -145,6 +145,10 @@ in
         programs = lib.mkMerge [
           (import ../shared/home-manager.nix { inherit config pkgs lib; })
           {
+            nvm = {
+              enable = true;
+              enableZshIntegration = true;
+            };
             agent-skills = {
               enable = true;
               sources.mine = {

--- a/modules/darwin/home-manager.nix
+++ b/modules/darwin/home-manager.nix
@@ -22,7 +22,7 @@ in
 
   homebrew = {
     enable = true;
-    brews = [ "rtk" "bastionzero/tap/zli" ];
+    brews = [ "rtk" "bastionzero/tap/zli" "nvm" ];
     casks = pkgs.callPackage ./casks.nix { };
   };
 
@@ -145,10 +145,6 @@ in
         programs = lib.mkMerge [
           (import ../shared/home-manager.nix { inherit config pkgs lib; })
           {
-            nvm = {
-              enable = true;
-              enableZshIntegration = true;
-            };
             agent-skills = {
               enable = true;
               sources.mine = {

--- a/modules/nixos/homelab/default.nix
+++ b/modules/nixos/homelab/default.nix
@@ -1,7 +1,7 @@
 { user, ... }:
 
 # Homelab service stack: torrenting (gluetun + qBittorrent), the *arr
-# automation suite, a Jellyfin media server, and a Caddy reverse proxy that
+# automation suite, Jellyfin + Plex media servers, and a Caddy reverse proxy that
 # exposes everything privately over the tailnet. See docs/ and the plan for the
 # overall design; each concern lives in its own file below.
 {
@@ -11,6 +11,7 @@
     ./torrent.nix
     ./arr.nix
     ./jellyfin.nix
+    ./plex.nix
     ./sabnzbd.nix
     ./proxy.nix
   ];

--- a/modules/nixos/homelab/plex.nix
+++ b/modules/nixos/homelab/plex.nix
@@ -1,0 +1,26 @@
+_:
+
+# Plex Media Server. Runs with primary group `media` for read access to the
+# NAS library (/mnt/nas/media). After first deploy, add media libraries in the
+# Plex setup wizard (e.g. /mnt/nas/media/movies, /mnt/nas/media/tv) and set
+# Settings → Remote Access → Custom server access URLs to
+# https://nixos.tail9fed5f.ts.net/plex so Caddy path-prefix routing works.
+{
+  services.plex = {
+    enable = true;
+    group = "media";
+    openFirewall = true;
+  };
+
+  # ── Hardware (VAAPI) transcoding ──────────────────────────────────────────────
+  # Same AMD Radeon (Polaris/GCN4) render node as the old Jellyfin setup.
+  # `hardware.graphics.enable` installs Mesa/radeonsi which Plex's bundled ffmpeg
+  # discovers automatically. Plex Pass required for hardware transcoding in Plex.
+  hardware.graphics.enable = true;
+
+  # Plex must be able to open the render node.
+  users.users.plex.extraGroups = [ "render" "video" ];
+
+  # After deploy, in Plex UI: Settings → Transcoder → Enable hardware-accelerated
+  # encoding (requires Plex Pass). VA-API device: /dev/dri/renderD128.
+}

--- a/modules/nixos/homelab/proxy.nix
+++ b/modules/nixos/homelab/proxy.nix
@@ -65,6 +65,14 @@ in
           tls ${certDir}/${host}.crt ${certDir}/${host}.key
 
           handle /jellyfin/*  { reverse_proxy 127.0.0.1:8096 }
+
+          # Plex: strip the /plex prefix before proxying so Plex sees its own paths.
+          # Set Settings → Remote Access → Custom server access URLs to
+          # https://nixos.tail9fed5f.ts.net/plex after initial setup.
+          handle /plex/*  {
+            uri strip_prefix /plex
+            reverse_proxy 127.0.0.1:32400
+          }
           handle /prowlarr/* { reverse_proxy 127.0.0.1:9696 }
           handle /sonarr/*   { reverse_proxy 127.0.0.1:8989 }
           handle /radarr/*   { reverse_proxy 127.0.0.1:7878 }

--- a/modules/shared/home-manager.nix
+++ b/modules/shared/home-manager.nix
@@ -64,6 +64,11 @@ in
       # nix clang-wrapper broke aws-lc-sys (missing dsymutil), and the append-based
       # CFLAGS/RUSTFLAGS exports duplicated on every shell re-source.
 
+      # NVM (installed via Homebrew on Darwin)
+      export NVM_DIR="$HOME/.nvm"
+      [ -s "/opt/homebrew/opt/nvm/nvm.sh" ] && \. "/opt/homebrew/opt/nvm/nvm.sh"
+      [ -s "/opt/homebrew/opt/nvm/etc/bash_completion.d/nvm" ] && \. "/opt/homebrew/opt/nvm/etc/bash_completion.d/nvm"
+
       # Use difftastic, syntax-aware diffing
       # alias diff=difft
 


### PR DESCRIPTION
This pull request adds Plex Media Server support to the NixOS homelab stack, updates the reverse proxy to route Plex traffic, and improves developer tooling for macOS. The most important changes are grouped below.

**Homelab media server enhancements:**

* Added a new `plex.nix` module to enable and configure Plex Media Server, including hardware transcoding support and proper group permissions for accessing the NAS media library.
* Updated `default.nix` in the homelab to include the new `plex.nix` module and updated documentation to reflect support for both Jellyfin and Plex media servers. [[1]](diffhunk://#diff-f8e60e39b65ce1852e2464182e843386201b4a875bc13bbcfd8b156adc4f278bL4-R4) [[2]](diffhunk://#diff-f8e60e39b65ce1852e2464182e843386201b4a875bc13bbcfd8b156adc4f278bR14)

**Reverse proxy configuration:**

* Modified the Caddy reverse proxy in `proxy.nix` to add a handler for `/plex/*` routes, correctly stripping the prefix and proxying requests to Plex. Includes setup instructions for Plex remote access.

**Developer tooling improvements (macOS):**

* Added `nvm` to Homebrew packages on macOS and updated shell initialization to source `nvm` scripts when available, improving Node.js version management for developers. [[1]](diffhunk://#diff-748844191ec6cd1739e3532745c54ba37e124ace32058b65c4e24b567c88c9e6L25-R25) [[2]](diffhunk://#diff-efd7947a893086ed1a46d88680cff88b33fc36170a350783720b319a251822beR67-R71)

**Deployment process improvements:**

* Updated `justfile` commands to use `nix run nixpkgs#nixos-rebuild` for more reliable and reproducible remote NixOS deployments.