### PR TITLE
feat(darwin): add OBS Studio cask for screen recording

### DIFF
--- a/modules/darwin/casks.nix
+++ b/modules/darwin/casks.nix
@@ -26,6 +26,9 @@ _:
   # "steam"
   "vlc"
 
+  # Screen Recording / Demos
+  "obs"
+
   # Productivity Tools
   "raycast"
   "asana"


### PR DESCRIPTION
Install OBS via the Homebrew cask `obs` so macOS gets the notarized .app bundle needed for Screen Recording/Camera TCC permissions and the virtual-camera system extension. Matches how other GUI apps (loom, vlc) are managed in this config.