### PR TITLE
feat: add awscurl to darwin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ result
 .DS_Store
 .aider*
 .claude/settings.local.json
+.playwright-mcp/

--- a/modules/darwin/packages.nix
+++ b/modules/darwin/packages.nix
@@ -4,6 +4,7 @@ with pkgs;
 let shared-packages = import ../shared/packages.nix { inherit pkgs; }; in
 shared-packages ++ [
   awscli2
+  awscurl
   fswatch
   dockutil
   devenv

--- a/overlays/awscurl.nix
+++ b/overlays/awscurl.nix
@@ -1,0 +1,31 @@
+# awscurl is not in nixpkgs, so package it from PyPI as a Python application.
+# https://github.com/okigan/awscurl
+_: prev: {
+  awscurl = prev.python3Packages.buildPythonApplication rec {
+    pname = "awscurl";
+    version = "0.44";
+    pyproject = true;
+
+    src = prev.fetchPypi {
+      inherit pname version;
+      hash = "sha256-EwVuhnrDP1VvKdNmIQK/w8QCWeoDfG2BfFkU27K72Ug=";
+    };
+
+    build-system = with prev.python3Packages; [ setuptools ];
+
+    dependencies = with prev.python3Packages; [
+      requests
+      configargparse
+      configparser
+      urllib3
+      boto3
+      botocore
+      awscrt
+    ];
+
+    # Upstream test suite hits the network and pulls extra dev deps.
+    doCheck = false;
+
+    pythonImportsCheck = [ "awscurl" ];
+  };
+}


### PR DESCRIPTION
This pull request adds support for the `awscurl` command-line tool to the Darwin (macOS) development environment by packaging it from PyPI, as it is not available in Nixpkgs. The main changes involve defining a new overlay to build `awscurl` as a Python application and including it in the list of installed packages.

**Addition of awscurl support:**

* Added a new overlay `overlays/awscurl.nix` to package `awscurl` from PyPI as a Python application, specifying its dependencies and disabling tests that require network access.
* Included `awscurl` in the list of Darwin packages in `modules/darwin/packages.nix` to ensure it is installed alongside other development tools.