### PR TITLE
feat(darwin): add tabularis cask + fix build skew, add changelog/change-notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,10 @@ Default label vocabulary — needs-triage, needs-info, ready-for-agent, ready-fo
 
 Single-context repo — one `CONTEXT.md` + `docs/adr/` at the repo root. See `docs/agents/domain.md`.
 
+### Change tracking
+
+Record notable changes in two places: surface-level lines in root `CHANGELOG.md`, and deeper "what changed and what caused it" notes in `docs/changes/` (dated `YYYY-MM-DD-slug.md` entries). See `docs/changes/README.md`.
+
 ### Available skills
 
 - **nix-profile-manager** (`.Codex/skills/nix-profile-manager/`) — manage local Nix profiles imperatively: install, search, and upgrade packages via `nix profile` without touching the system config. Read `SKILL.md` before running any `nix profile` commands; consult `references/` for flakes, package search, profile internals, and registry configuration.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+All notable changes to this repo are recorded here. The format is based on
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/). This repo has no
+tagged releases or semver, so changes are grouped under **dated** sections
+instead of version numbers, with `[Unreleased]` at the top for in-flight work.
+
+Entries are surface-level and PR-referenced. Deeper explanations of _what
+changed and what caused it_ live in [`docs/changes/`](docs/changes/).
+
+## [Unreleased]
+
+## 2026-07-06
+
+### Added
+
+- Tabularis DB desktop app as a Homebrew cask, via a new declarative `TabularisDB/homebrew-tabularis` tap (flake input) and a `tabularis` entry in `modules/darwin/casks.nix`. Note: Homebrew 6 requires a one-time `brew trust --cask tabularisdb/tabularis/tabularis` before the cask installs. (PR TBD)
+
+### Fixed
+
+- Darwin system build failing on `darwin-manual-html`: the pinned nix-darwin (Apr 2025) renders its manual with the now-removed `nixos-render-docs --toc-depth` flag under current nixpkgs. Disabled the manual + uninstaller (`documentation.enable = false`, `system.tools.darwin-uninstaller.enable = false`) in `hosts/darwin/configuration.nix`. (PR TBD)
+- `_1password-gui` fixed-output hash mismatch after 1Password re-published the 8.12.26 artifact; updated the pinned hash in `overlays/_1password-gui-hash.nix`. (PR TBD)
+
+→ details: [`docs/changes/2026-07-06-tabularis-and-darwin-skew.md`](docs/changes/2026-07-06-tabularis-and-darwin-skew.md)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,11 @@ changed and what caused it_ live in [`docs/changes/`](docs/changes/).
 
 ### Added
 
-- Tabularis DB desktop app as a Homebrew cask, via a new declarative `TabularisDB/homebrew-tabularis` tap (flake input) and a `tabularis` entry in `modules/darwin/casks.nix`. Note: Homebrew 6 requires a one-time `brew trust --cask tabularisdb/tabularis/tabularis` before the cask installs. (PR TBD)
+- Tabularis DB desktop app as a Homebrew cask, via a new declarative `TabularisDB/homebrew-tabularis` tap (flake input) and a `tabularis` entry in `modules/darwin/casks.nix`. Note: Homebrew 6 requires a one-time `brew trust --cask tabularisdb/tabularis/tabularis` before the cask installs. ([#90](https://github.com/parallaxisjones/dotfiles/pull/90))
 
 ### Fixed
 
-- Darwin system build failing on `darwin-manual-html`: the pinned nix-darwin (Apr 2025) renders its manual with the now-removed `nixos-render-docs --toc-depth` flag under current nixpkgs. Disabled the manual + uninstaller (`documentation.enable = false`, `system.tools.darwin-uninstaller.enable = false`) in `hosts/darwin/configuration.nix`. (PR TBD)
-- `_1password-gui` fixed-output hash mismatch after 1Password re-published the 8.12.26 artifact; updated the pinned hash in `overlays/_1password-gui-hash.nix`. (PR TBD)
+- Darwin system build failing on `darwin-manual-html`: the pinned nix-darwin (Apr 2025) renders its manual with the now-removed `nixos-render-docs --toc-depth` flag under current nixpkgs. Disabled the manual + uninstaller (`documentation.enable = false`, `system.tools.darwin-uninstaller.enable = false`) in `hosts/darwin/configuration.nix`. ([#90](https://github.com/parallaxisjones/dotfiles/pull/90))
+- `_1password-gui` fixed-output hash mismatch after 1Password re-published the 8.12.26 artifact; updated the pinned hash in `overlays/_1password-gui-hash.nix`. ([#90](https://github.com/parallaxisjones/dotfiles/pull/90))
 
 → details: [`docs/changes/2026-07-06-tabularis-and-darwin-skew.md`](docs/changes/2026-07-06-tabularis-and-darwin-skew.md)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,10 @@ Default label vocabulary — needs-triage, needs-info, ready-for-agent, ready-fo
 
 Single-context repo — one `CONTEXT.md` + `docs/adr/` at the repo root. See `docs/agents/domain.md`.
 
+### Change tracking
+
+Record notable changes in two places: surface-level lines in root `CHANGELOG.md`, and deeper "what changed and what caused it" notes in `docs/changes/` (dated `YYYY-MM-DD-slug.md` entries). See `docs/changes/README.md`.
+
 ### Available skills
 
 - **nix-profile-manager** (`.claude/skills/nix-profile-manager/`) — manage local Nix profiles imperatively: install, search, and upgrade packages via `nix profile` without touching the system config. Read `SKILL.md` before running any `nix profile` commands; consult `references/` for flakes, package search, profile internals, and registry configuration.

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ See `docs/ROADMAP.md` for details and backlog.
 Apps are pre-wired scripts that run under `nix run .#<app>`. They are defined per system in `flake.nix`, and the repo provides implementations in `apps/<system>/`.
 
 Common examples:
+
 - On macOS:
   - `nix run .#build` — build the current Darwin config
   - `nix run .#build-switch` — build and activate Darwin config
@@ -55,6 +56,7 @@ Common examples:
   - `nix run .#install-with-secrets` — install flow with secrets provisioning
 
 Notes:
+
 - Apps are system-specific; the correct variant is selected by your machine’s architecture (e.g., `x86_64-linux`, `aarch64-linux`, `aarch64-darwin`).
 - Some scripts expect SSH forwarding for secrets or remote builders. See `docs/DEPLOYMENT.md` and `docs/REMOTE_BUILDERS.md`.
 
@@ -63,6 +65,7 @@ Notes:
 Use a beefy x86_64 NixOS builder to compile `aarch64-linux` and `x86_64-linux`, and offload from macOS M3.
 
 Quick setup:
+
 - On the builder (NixOS):
   - Enable ARM emulation if needed:
     ```nix
@@ -83,6 +86,7 @@ Quick setup:
     ```
 
 Verify:
+
 - List systems in this flake: `nix eval .#nixosConfigurations --apply builtins.attrNames`
 - Test remote build: `nix build .#nixosConfigurations.<host>.config.system.build.toplevel`
   (from macOS, the work should occur on `nixos`).
@@ -109,8 +113,10 @@ See `docs/REMOTE_BUILDERS.md` for details.
 
 ## Documentation
 
+- `CHANGELOG.md` – surface-level log of notable changes (dated, PR-referenced)
+- `docs/changes/` – deeper change notes: what changed and what caused it
 - `docs/ROADMAP.md` – phased plan and current state
 - `docs/HELIOS64.md` – RK3399/Helios64 checklist and install notes
 - `docs/REMOTE_BUILDERS.md` – x86 builder and macOS M3 flows
-- `docs/DEPLOYMENT.md` – deploy-rs and nixos-anywhere usage
+- `docs/DEPLOYMENT.md` – first install (nixos-anywhere, deploy-rs) + macOS Homebrew tap-trust step
 - `docs/BOOTSTRAP_KEYS.md` – bootstrap and key management guide

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,24 +1,52 @@
 # Deployment – First Install and Ongoing Updates
 
 ## First Install with nixos-anywhere + disko (recommended)
+
 - Requirements: reachable SSH host, working bootloader, and installer access (for ARM boards, Tow-Boot/U-Boot as needed).
 - Command pattern:
+
 ```
 nix run github:numtide/nixos-anywhere -- --flake .#<aarch64-system> <ssh-host>
 ```
+
 - Use `disko` for partitioning; prefer a dry-run before destructive operations.
 
+## macOS (nix-darwin) first install
+
+- Build and activate: `nix run .#build-switch` (wraps `sudo darwin-rebuild switch --flake .#aarch64-darwin`).
+- **Homebrew third-party tap trust (Homebrew 6+).** On a fresh machine the first `build-switch` activates fine, but the `brew bundle` step then refuses to install casks/formulae from any non-official tap:
+
+  ```
+  Error: Refusing to load cask <tap>/<cask> from untrusted tap <tap>.
+  Run `brew trust --cask <tap>/<cask>` or `brew trust <tap>` to trust it.
+  `brew bundle` failed! Failed to fetch <cask>
+  ```
+
+  Homebrew enforces `$HOMEBREW_REQUIRE_TAP_TRUST`; the `trusted: true` that our pinned (Apr 2025) nix-darwin writes into the generated Brewfile is **not** honored by Homebrew 6. Trust each non-official tap declared in `flake.nix` (`nix-homebrew.taps`) once, then re-run `build-switch` (or `brew install` the item directly). The official `homebrew/*` taps need no trust. Current third-party items:
+
+  ```
+  brew trust --cask tabularisdb/tabularis/tabularis   # tabularis (DB desktop app)
+  brew trust --formula bastionzero/tap/zli            # zli
+  ```
+
+  Trust is recorded in `~/.homebrew/trust.json` — **per-machine** state that persists across rebuilds and is independent of the read-only nix-homebrew tap mount. It is not part of the Nix config, so it must be re-done on every new machine. Background and root cause: `docs/changes/2026-07-06-tabularis-and-darwin-skew.md`.
+
 ## Ongoing updates with deploy-rs (recommended)
+
 - Command pattern:
+
 ```
 nix run github:serokell/deploy-rs -- --flake .#<node>
 ```
+
 - Configure `deploy.nodes.<node>` in your flake to point at the host (SSH alias, user, activation path).
 
 ## Rollbacks
+
 - NixOS: `sudo nixos-rebuild --rollback switch` or select previous generation at boot.
 - macOS (nix-darwin): `darwin-rebuild --rollback switch`.
 
 ## Tips
+
 - Always `nix flake show` and/or `nix build` first for the target system.
 - Keep deployments small and frequent for easy rollbacks.

--- a/docs/changes/2026-07-06-tabularis-and-darwin-skew.md
+++ b/docs/changes/2026-07-06-tabularis-and-darwin-skew.md
@@ -1,0 +1,55 @@
+# Change: Tabularis cask + nix-darwin/nixpkgs skew fixes
+
+- Date: 2026-07-06
+- PR / commit: PR TBD (changes currently in the working tree; last merged PR was #89)
+- Related ADRs: none
+
+## What changed
+
+- Added the **Tabularis** database desktop app as a Homebrew cask:
+  - New flake input `tabularis-tap` → `github:TabularisDB/homebrew-tabularis` (`flake = false`) in `flake.nix`, threaded through the `outputs = { … }` args.
+  - Mapped `"TabularisDB/homebrew-tabularis" = tabularis-tap;` under `nix-homebrew.taps` in `flake.nix`.
+  - Added `"tabularis"` to `modules/darwin/casks.nix`.
+  - Locked the input in `flake.lock` (`042c2e2`, 2026-07-01) — no other inputs bumped.
+- Fixed a **pre-existing** broken darwin build (unrelated to Tabularis, blocking every `build-switch`):
+  - `documentation.enable = false;` in `hosts/darwin/configuration.nix`.
+  - `system.tools.darwin-uninstaller.enable = false;` in `hosts/darwin/configuration.nix`.
+- Fixed a second pre-existing break: bumped the `_1password-gui` source hash in `overlays/_1password-gui-hash.nix`
+  (`sha256-Rbac0…` → `sha256-bZD8…`).
+
+## What caused it (trigger / root cause)
+
+The trigger was a simple request: "install Tabularis via `brew tap … && brew install --cask tabularis`." That surfaced four deeper causes:
+
+1. **Homebrew is declarative here.** This repo runs `nix-homebrew` with `mutableTaps = false`, so imperative `brew tap` is locked out and casks are reconciled from config. Tabularis had to be added as a flake-input tap + a `casks.nix` entry, following the existing `bastionzero-tap` pattern — not installed by hand.
+
+2. **nix-darwin ↔ nixpkgs version skew.** The `darwin` input is pinned to ~Apr 2025 (`43975d7`) while nixpkgs is ~Jul 2026 (`d407951`) after recent `chore: update flake.lock` PRs. The old nix-darwin builds its manual with `nixos-render-docs … --toc-depth`, a flag the current nixpkgs removed (_"--toc-depth has been removed, use --sidebar-depth instead"_), so `darwin-manual-html` failed. `documentation.enable = false` removed the manual from the top-level system, but `pkgs/darwin-uninstaller` evaluates its **own** default (docs-enabled) system via `eval-config.nix`, which dragged `darwin-manual-html` back into the closure through `system-path` — hence also disabling the uninstaller tool.
+
+3. **1Password re-published its artifact.** 1Password served new bytes for 8.12.26 at the same URL, so the fixed-output hash pinned in `overlays/_1password-gui-hash.nix` no longer matched. `_1password-gui` is pulled into the darwin build via git SSH signing (`sshProgram = "${pkgs._1password-gui}/bin/op-ssh-sign"` in `modules/shared/home-manager.nix`). Updating the hash to the currently-served value is this repo's established pattern for 1Password's periodic re-publishes.
+
+4. **Homebrew 6 tap-trust gate.** After a successful `darwin-rebuild switch`, `brew bundle` still refused the cask: _"Refusing to load cask … from untrusted tap."_ Homebrew 6.0.1 enforces `$HOMEBREW_REQUIRE_TAP_TRUST`, so non-official taps must be explicitly trusted. The pinned nix-darwin emits `cask "tabularis", trusted: true` in the Brewfile, but Homebrew 6 no longer honors that flag (another skew). The fix is a one-time `brew trust --cask tabularisdb/tabularis/tabularis`, which records trust in `~/.homebrew/trust.json` — local machine state, independent of the read-only nix-homebrew tap mount, and persistent across rebuilds (but absent on a fresh machine).
+
+## How it was done
+
+- Verified the tap repo/cask names via the GitHub API (`TabularisDB/homebrew-tabularis`, branch `main`, `Casks/tabularis.rb`).
+- Added the input, tap mapping, and cask; ran `nix flake lock` to add only the new input.
+- Traced the manual failure with `nix why-depends --derivation` to find the `darwin-uninstaller → inner system → system-path → darwin-manual-html` chain, then read `pkgs/darwin-uninstaller/default.nix` and `modules/documentation/default.nix` in the pinned nix-darwin source to confirm the two toggles needed.
+- Took the 1Password `got:` hash straight from the build's mismatch error.
+
+## Verification
+
+- `nix build .#darwinConfigurations.aarch64-darwin.system` succeeds and produces a `darwin-system-26.11` result (no sudo / switch required to build).
+- `nix eval … .config.homebrew.casks` shows `cask "tabularis", trusted: true`.
+- `nix eval … .config.nix-homebrew.taps` includes `TabularisDB/homebrew-tabularis`.
+- Dry-build build plan no longer contains `darwin-manual-html` / `darwin-help` / `render-docs`.
+- `sudo darwin-rebuild switch --flake .#aarch64-darwin` (or `nix run .#build-switch`) succeeds and switches the generation; the Homebrew activation taps the repo declaratively.
+- Installing the cask required the one-time trust above, then it installed cleanly: `brew trust --cask tabularisdb/tabularis/tabularis` → `tabularis 0.13.4` in `/Applications/tabularis.app` (confirmed via `brew list --cask`).
+
+## Links
+
+- CHANGELOG entry: [`CHANGELOG.md`](../../CHANGELOG.md) → 2026-07-06
+- Source files: `flake.nix`, `flake.lock`, `modules/darwin/casks.nix`, `hosts/darwin/configuration.nix`, `overlays/_1password-gui-hash.nix`
+- Pattern reference: the existing `bastionzero-tap` wiring in `flake.nix`
+- New-machine runbook: `docs/DEPLOYMENT.md` → "macOS (nix-darwin) first install" (Homebrew tap-trust step)
+- Upstream: nixpkgs `nixos-render-docs` removal of `--toc-depth` (use `--sidebar-depth`); 1Password 8.12.26 artifact re-publish
+- Related ADRs: none

--- a/docs/changes/2026-07-06-tabularis-and-darwin-skew.md
+++ b/docs/changes/2026-07-06-tabularis-and-darwin-skew.md
@@ -1,7 +1,7 @@
 # Change: Tabularis cask + nix-darwin/nixpkgs skew fixes
 
 - Date: 2026-07-06
-- PR / commit: PR TBD (changes currently in the working tree; last merged PR was #89)
+- PR / commit: [#90](https://github.com/parallaxisjones/dotfiles/pull/90)
 - Related ADRs: none
 
 ## What changed

--- a/docs/changes/README.md
+++ b/docs/changes/README.md
@@ -1,0 +1,24 @@
+# Change Notes
+
+Deeper explanations of **what changed and what caused it**. Where the root [`CHANGELOG.md`](../../CHANGELOG.md) is the scannable, one-line-per-change surface log, change notes are the narrative behind an entry: the trigger, the root cause, how it was done, and how it was verified.
+
+## How this differs from ADRs
+
+- **ADRs (`docs/adr/`)** are _timeless, decision-centric_: "we decided to use ZFS." Their status reflects current validity; they're superseded, not dated-out.
+- **Change notes (`docs/changes/`)** are _temporal, change-centric_: "on this date these things changed, and here's what forced them." They are a historical record and don't get superseded.
+
+If a change embodies a lasting structural decision, write an ADR too and cross-link it.
+
+## Conventions
+
+- Files are named `YYYY-MM-DD-slug.md` (dated, so they sort chronologically).
+- One note per meaningful change or batch of related changes. Keep it specific; split if it sprawls across unrelated topics.
+- Each note should link back to its `CHANGELOG.md` line, the source files it touched, and any related ADRs.
+
+## Template
+
+Copy [`_template.md`](_template.md) and rename it to `YYYY-MM-DD-your-slug.md`.
+
+## Index
+
+- 2026-07-06 — [Tabularis cask + nix-darwin/nixpkgs skew fixes](2026-07-06-tabularis-and-darwin-skew.md)

--- a/docs/changes/_template.md
+++ b/docs/changes/_template.md
@@ -1,0 +1,29 @@
+# Change: <title>
+
+- Date: YYYY-MM-DD
+- PR / commit: #NN (or commit hash)
+- Related ADRs: none | ADR NNNN
+
+## What changed
+
+Surface list of the concrete changes — files touched, behavior added/removed. This should line up with the corresponding `CHANGELOG.md` entry, just with a little more detail.
+
+## What caused it (trigger / root cause)
+
+Why now? What request, breakage, or upstream event triggered this? Dig past the symptom to the real root cause — the thing that, if someone reads this in a year, explains _why_ the change was necessary.
+
+## How it was done
+
+Implementation summary and the key files/mechanisms involved. Enough that a reader could follow or reverse it.
+
+## Verification
+
+How the change was validated — commands run and their expected output, evals, tests, or manual checks.
+
+## Links
+
+- CHANGELOG entry
+- Source files
+- Related ADRs
+- Upstream issues / PRs
+- Memory notes

--- a/flake.lock
+++ b/flake.lock
@@ -297,7 +297,8 @@
         "my-skills": "my-skills",
         "nix-homebrew": "nix-homebrew",
         "nixpkgs": "nixpkgs",
-        "secrets": "secrets"
+        "secrets": "secrets",
+        "tabularis-tap": "tabularis-tap"
       }
     },
     "rust-analyzer-src": {
@@ -345,6 +346,22 @@
       "original": {
         "owner": "nix-systems",
         "repo": "default",
+        "type": "github"
+      }
+    },
+    "tabularis-tap": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1782898960,
+        "narHash": "sha256-CocE/Fjmyes6xtf8zDofq3jLpI29v/BTuwCPJv8aVUU=",
+        "owner": "TabularisDB",
+        "repo": "homebrew-tabularis",
+        "rev": "042c2e23596998ac22c09fdbf46eca01ffb19d7b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "TabularisDB",
+        "repo": "homebrew-tabularis",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -34,6 +34,10 @@
       url = "github:bastionzero/homebrew-tap";
       flake = false;
     };
+    tabularis-tap = {
+      url = "github:TabularisDB/homebrew-tabularis";
+      flake = false;
+    };
     disko = {
       url = "github:nix-community/disko";
       inputs.nixpkgs.follows = "nixpkgs";
@@ -56,7 +60,7 @@
       url = "github:parallaxisjones/skills";
     };
   };
-  outputs = { self, darwin, nix-homebrew, homebrew-bundle, homebrew-core, homebrew-cask, bastionzero-tap, home-manager, nixpkgs, disko, fenix, ... } @inputs:
+  outputs = { self, darwin, nix-homebrew, homebrew-bundle, homebrew-core, homebrew-cask, bastionzero-tap, tabularis-tap, home-manager, nixpkgs, disko, fenix, ... } @inputs:
     let
       user = "parallaxis";
       workUser = "pjones";
@@ -209,6 +213,7 @@
                   "homebrew/homebrew-cask" = homebrew-cask;
                   "homebrew/homebrew-bundle" = homebrew-bundle;
                   "bastionzero/homebrew-tap" = bastionzero-tap;
+                  "TabularisDB/homebrew-tabularis" = tabularis-tap;
                 };
                 mutableTaps = false;
                 autoMigrate = true;

--- a/hosts/darwin/configuration.nix
+++ b/hosts/darwin/configuration.nix
@@ -20,11 +20,6 @@ in
   # current nixpkgs removed ("use --sidebar-depth instead"), which breaks the
   # build. Disabling docs sidesteps the skew without bumping nix-darwin.
   documentation.enable = false;
-  # darwin-uninstaller bundles its own default system evaluation (with docs
-  # enabled) that re-introduces the broken manual into our closure, so it can't
-  # be reached by documentation.enable above. Drop the uninstaller tool too;
-  # if ever needed it can still be run via `nix run nix-darwin#darwin-uninstaller`.
-  system.tools.darwin-uninstaller.enable = false;
 
   nix = {
     package = pkgs.nix;
@@ -92,27 +87,6 @@ in
     # mcp-hub removed
   ];
 
-  # Ensure ~/.ssh/known_hosts is a writable regular file, not a symlink, to avoid SSH known_hosts update issues
-  system.activationScripts.fixKnownHosts = {
-    deps = [ ];
-    text = ''
-      USER_HOME="/Users/pjones"
-      KNOWN_HOSTS="$USER_HOME/.ssh/known_hosts"
-      mkdir -p "$USER_HOME/.ssh"
-      if [ -L "$KNOWN_HOSTS" ]; then
-        echo "Replacing symlinked known_hosts with a regular file"
-        rm -f "$KNOWN_HOSTS"
-        touch "$KNOWN_HOSTS"
-        chown pjones:staff "$KNOWN_HOSTS"
-        chmod 600 "$KNOWN_HOSTS"
-      elif [ ! -e "$KNOWN_HOSTS" ]; then
-        touch "$KNOWN_HOSTS"
-        chown pjones:staff "$KNOWN_HOSTS"
-        chmod 600 "$KNOWN_HOSTS"
-      fi
-    '';
-  };
-
   # nix-darwin manages nix-daemon automatically when nix is enabled
 
   # Provide the remote builders file referenced above
@@ -132,6 +106,35 @@ in
   system = {
     stateVersion = 4;
     primaryUser = "pjones";
+
+    # darwin-uninstaller bundles its own default system evaluation (with docs
+    # enabled) that re-introduces the broken manual into our closure, so it
+    # can't be reached by documentation.enable above. Drop the uninstaller tool
+    # too; if ever needed, run `nix run nix-darwin#darwin-uninstaller`.
+    tools.darwin-uninstaller.enable = false;
+
+    # Ensure ~/.ssh/known_hosts is a writable regular file, not a symlink, to
+    # avoid SSH known_hosts update issues.
+    activationScripts.fixKnownHosts = {
+      deps = [ ];
+      text = ''
+        USER_HOME="/Users/pjones"
+        KNOWN_HOSTS="$USER_HOME/.ssh/known_hosts"
+        mkdir -p "$USER_HOME/.ssh"
+        if [ -L "$KNOWN_HOSTS" ]; then
+          echo "Replacing symlinked known_hosts with a regular file"
+          rm -f "$KNOWN_HOSTS"
+          touch "$KNOWN_HOSTS"
+          chown pjones:staff "$KNOWN_HOSTS"
+          chmod 600 "$KNOWN_HOSTS"
+        elif [ ! -e "$KNOWN_HOSTS" ]; then
+          touch "$KNOWN_HOSTS"
+          chown pjones:staff "$KNOWN_HOSTS"
+          chmod 600 "$KNOWN_HOSTS"
+        fi
+      '';
+    };
+
     defaults = {
       dock = {
         autohide = true;

--- a/hosts/darwin/configuration.nix
+++ b/hosts/darwin/configuration.nix
@@ -14,6 +14,18 @@ in
     ../../modules/darwin/claude-code-managed.nix
     ../../modules/shared
   ];
+
+  # Skip building nix-darwin's HTML manual / `darwin help`. The pinned nix-darwin
+  # (Apr 2025) renders docs via `nixos-render-docs ... --toc-depth`, a flag the
+  # current nixpkgs removed ("use --sidebar-depth instead"), which breaks the
+  # build. Disabling docs sidesteps the skew without bumping nix-darwin.
+  documentation.enable = false;
+  # darwin-uninstaller bundles its own default system evaluation (with docs
+  # enabled) that re-introduces the broken manual into our closure, so it can't
+  # be reached by documentation.enable above. Drop the uninstaller tool too;
+  # if ever needed it can still be run via `nix run nix-darwin#darwin-uninstaller`.
+  system.tools.darwin-uninstaller.enable = false;
+
   nix = {
     package = pkgs.nix;
     settings = {

--- a/modules/darwin/casks.nix
+++ b/modules/darwin/casks.nix
@@ -38,4 +38,7 @@ _:
 
   # AI
   "diffusionbee"
+
+  # Databases
+  "tabularis"
 ]

--- a/overlays/_1password-gui-hash.nix
+++ b/overlays/_1password-gui-hash.nix
@@ -3,7 +3,7 @@ if prev.stdenv.isDarwin then {
   _1password-gui = prev._1password-gui.overrideAttrs (old: {
     src = prev.fetchurl {
       inherit (old.src) url;
-      hash = "sha256-Rbac0JcB2kbH6EfEGkuKwhaIW0Bgkhyw7olSjqe1euE=";
+      hash = "sha256-bZD8LCLTGXRpNF/FqoSHvI69pquAcQGa1mdagWypgDU=";
     };
   });
 } else { }


### PR DESCRIPTION
## Summary

Adds the **Tabularis** DB desktop app declaratively, unblocks the darwin build (two pre-existing version-skew breakages), and introduces a change-tracking docs system.

### Feature + fixes (`feat(darwin)` commit)
- **Tabularis cask** via a new declarative `TabularisDB/homebrew-tabularis` tap (flake input + `nix-homebrew.taps` + `modules/darwin/casks.nix`). Imperative `brew tap` is blocked here by `mutableTaps = false`.
- **Fix darwin build skew:** the pinned nix-darwin (Apr 2025) renders its manual with the now-removed `nixos-render-docs --toc-depth` flag under current nixpkgs. Set `documentation.enable = false` and `system.tools.darwin-uninstaller.enable = false` (the uninstaller's embedded default system otherwise drags the manual back in).
- **Fix 1Password hash:** bumped `_1password-gui` src hash after 1Password re-published the 8.12.26 artifact.

### Docs (`docs` commit)
- Root **`CHANGELOG.md`** (Keep a Changelog style, dated sections — no semver/tags here).
- New **`docs/changes/`** change-notes class (README + template), distinct from timeless ADRs, seeded with the tabularis/skew note.
- **`docs/DEPLOYMENT.md`** macOS first-install section documenting the Homebrew 6 tap-trust step for fresh machines.
- Discovery wiring in `README.md`, `CLAUDE.md`, `AGENTS.md`.

## Verification
- `nix build .#darwinConfigurations.aarch64-darwin.system` succeeds.
- `darwin-rebuild switch` applied; `tabularis 0.13.4` installed to `/Applications/tabularis.app` (after the documented one-time `brew trust --cask tabularisdb/tabularis/tabularis`).
- All Markdown passes `prettier --check`.

## Note
Homebrew 6 requires a **one-time** `brew trust --cask tabularisdb/tabularis/tabularis` on each machine (stored in `~/.homebrew/trust.json`, not in Nix). Documented in `docs/DEPLOYMENT.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)