### PR TITLE
feat: added diffview and neogit to neovim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ changed and what caused it_ live in [`docs/changes/`](docs/changes/).
 
 ## [Unreleased]
 
+### Added
+
+- Neovim: `neogit` (git staging/commit UI) and `diffview.nvim` (diff + file-history viewer) plugins, lazy-loaded on command, in `modules/shared/config/nvim/lua/custom/plugins.lua`. Neogit is wired to telescope + diffview. New leader bindings in `custom/mappings.lua`: `<leader>gd` → `:DiffviewOpen`, `<leader>gh` → `:DiffviewFileHistory %`, `<leader>gs` → `:Neogit`.
+
+→ details: [`docs/changes/2026-07-08-neovim-neogit-diffview.md`](docs/changes/2026-07-08-neovim-neogit-diffview.md)
+
 ## 2026-07-06
 
 ### Added

--- a/docs/changes/2026-07-08-neovim-neogit-diffview.md
+++ b/docs/changes/2026-07-08-neovim-neogit-diffview.md
@@ -1,0 +1,63 @@
+# Change: Add Neogit + Diffview to Neovim with leader bindings
+
+- Date: 2026-07-08
+- PR / commit: (pending)
+- Related ADRs: none
+
+## What changed
+
+- Added two Lazy.nvim plugin specs to `modules/shared/config/nvim/lua/custom/plugins.lua`:
+  - `sindrets/diffview.nvim` — diff and file-history viewer, lazy-loaded on its
+    `Diffview*` commands, with `nvim-lua/plenary.nvim` as a dependency.
+  - `NeogitOrg/neogit` — git staging/commit UI, lazy-loaded on the `Neogit`
+    command, wired to `plenary`, `diffview.nvim` (richer diffs), and
+    `nvim-telescope/telescope.nvim` (telescope-backed pickers).
+- Added three normal-mode leader bindings to
+  `modules/shared/config/nvim/lua/custom/mappings.lua` (`M.general.n`):
+  - `<leader>gd` → `:DiffviewOpen`
+  - `<leader>gh` → `:DiffviewFileHistory %` (history for the current file)
+  - `<leader>gs` → `:Neogit`
+
+## What caused it (trigger / root cause)
+
+User request: wanted a dedicated git-review workflow inside Neovim (Neogit for
+staging/committing, Diffview for browsing diffs and file history) with the
+plugin authors' recommended leader bindings, provided they didn't clash with
+existing mappings.
+
+## How it was done
+
+- The nvim config is an NvChad (Lazy.nvim) setup vendored as lua files under
+  `modules/shared/config/nvim/`. `~/.config/nvim` is a recursive Nix symlink
+  (`modules/shared/files.nix`) into the read-only store, so the plugins are
+  managed by Lazy.nvim (not Nix) and install on next nvim startup after a
+  rebuild.
+- Both plugins are declared with `cmd = { ... }` so they cost nothing at
+  startup; the leader mappings invoke those commands, which triggers the
+  lazy-load on first use.
+- Bindings were placed in `custom/mappings.lua` (NvChad table format) rather
+  than plugin-local `keys`, so they surface in the NvChad cheatsheet /
+  which-key alongside the other leader mappings.
+
+### Conflict check
+
+Requested bindings were verified against all existing `<leader>g*` mappings.
+Only `<leader>gt` (Telescope git_status) and `<leader>gb` (gitsigns blame line)
+were in use; `<leader>gd`, `<leader>gh`, and `<leader>gs` were all free.
+
+## Verification
+
+- `nvim --headless -c "lua assert(loadfile('lua/custom/plugins.lua'))" -c q`
+  and the same for `lua/custom/mappings.lua` — both parse without error.
+- Full activation is pending a `darwin-rebuild switch` (to update the symlinked
+  store copy) followed by an nvim restart, which lets Lazy.nvim install the two
+  plugins. After that, `<leader>gd/gh/gs` should open Diffview / file history /
+  Neogit respectively.
+
+## Links
+
+- CHANGELOG entry: `CHANGELOG.md` → `[Unreleased]`
+- Source files: `modules/shared/config/nvim/lua/custom/plugins.lua`,
+  `modules/shared/config/nvim/lua/custom/mappings.lua`
+- Upstream: https://github.com/NeogitOrg/neogit,
+  https://github.com/sindrets/diffview.nvim

--- a/modules/shared/config/nvim/lua/custom/mappings.lua
+++ b/modules/shared/config/nvim/lua/custom/mappings.lua
@@ -11,7 +11,12 @@ M.general = {
         require("conform").format()
       end,
       "formatting",
-    }
+    },
+
+    -- git: diffview + neogit
+    ["<leader>gd"] = { "<cmd> DiffviewOpen <CR>", "Diffview open" },
+    ["<leader>gh"] = { "<cmd> DiffviewFileHistory % <CR>", "Diffview file history (current file)" },
+    ["<leader>gs"] = { "<cmd> Neogit <CR>", "Neogit status" },
 
   },
   v = {

--- a/modules/shared/config/nvim/lua/custom/plugins.lua
+++ b/modules/shared/config/nvim/lua/custom/plugins.lua
@@ -161,6 +161,25 @@ local plugins = {
     end,
   },
 
+  -- Git: staging/committing UI (Neogit) + diff & file-history viewer (Diffview)
+  {
+    "sindrets/diffview.nvim",
+    cmd = { "DiffviewOpen", "DiffviewClose", "DiffviewToggleFiles", "DiffviewFocusFiles", "DiffviewFileHistory" },
+    dependencies = { "nvim-lua/plenary.nvim" },
+    opts = {},
+  },
+
+  {
+    "NeogitOrg/neogit",
+    cmd = "Neogit",
+    dependencies = {
+      "nvim-lua/plenary.nvim",
+      "sindrets/diffview.nvim", -- richer diffs inside Neogit
+      "nvim-telescope/telescope.nvim", -- telescope-backed pickers
+    },
+    opts = {},
+  },
+
   {
     "obsidian-nvim/obsidian.nvim",
     lazy = true,


### PR DESCRIPTION
This pull request adds a dedicated Git workflow to the Neovim configuration by introducing the Neogit and Diffview plugins, along with new leader key bindings for quick access. These plugins are set up for lazy-loading to minimize startup cost and are integrated with existing tools like Telescope. The configuration and mappings are verified to avoid conflicts with existing shortcuts.

**Neovim Git workflow enhancements:**

- **Plugins added:**
  - Added `Neogit` (`NeogitOrg/neogit`) for a Git staging/commit UI, lazy-loaded on the `Neogit` command, with dependencies on `plenary.nvim`, `diffview.nvim` (for richer diffs), and `telescope.nvim` (for pickers). (`modules/shared/config/nvim/lua/custom/plugins.lua`)
  - Added `diffview.nvim` (`sindrets/diffview.nvim`) for diff and file-history viewing, lazy-loaded on `Diffview*` commands, with dependency on `plenary.nvim`. (`modules/shared/config/nvim/lua/custom/plugins.lua`)

- **Key bindings:**
  - Introduced three new leader key mappings in normal mode for quick access: `<leader>gd` opens Diffview, `<leader>gh` shows file history for the current file, and `<leader>gs` opens Neogit. (`modules/shared/config/nvim/lua/custom/mappings.lua`)

**Documentation and changelog:**

- Added a detailed changelog entry describing the new plugins, their configuration, and the rationale for the changes. (`CHANGELOG.md`)
- Created a documentation file outlining what changed, the motivation, implementation details, conflict checks, and verification steps. (`docs/changes/2026-07-08-neovim-neogit-diffview.md`)